### PR TITLE
release: v0.9.0 (thin Rust core, Python Polars GPU-ready processing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "evlib"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name            = "evlib"
-version         = "0.8.7"
+version         = "0.9.0"
 authors         = ["Tarek Allam <t.allam.jr@gmail.com>"]
 edition         = "2021"
 resolver        = "2"


### PR DESCRIPTION
# release: v0.9.0 (thin Rust core, Python Polars GPU-ready processing)

## What

Bumps the version `0.8.7 -> 0.9.0` to publish the thin-Rust-core refactor to PyPI. Merging this PR to `master` triggers `publish.yml`, which builds the manylinux/macOS/Windows wheels and publishes `evlib==0.9.0` to PyPI.

## Why 0.9.0 (minor bump)

The refactor in #46 makes notable, behaviour-affecting changes that warrant a minor bump in 0.x:

- The native extension is now the private submodule `evlib._evlib`; `import evlib` loads the Python package deterministically (was a packaging ambiguity before).
- All DataFrame processing (filtering, representations, load-time filters) is now pure Python Polars and GPU-acceleratable via cudf-polars; the Rust `ev_filtering`/`ev_augmentation` modules were removed.
- `evlib.load_events` applies filters as Polars expressions and now defaults to `sort=True`.

The public Python API (`load_events`, `detect_format`, `formats`/`core` submodules, `filtering`, `representations`, `rvt`, engine helpers, `version`) is preserved.

## Verification

- The release wheel was built locally (`maturin build --release --features python,polars,arrow`) and installed into a clean venv: importing from outside the source tree gives `__loader__ == SourceFileLoader`, `evlib.version()` works, `evlib.filtering` is the Python module, and `evlib.rvt`/`load_events` resolve. The `evlib/_evlib.*.so` extension is correctly packaged inside the wheel.
- CI on #46 was green across Python 3.10/3.11/3.12 (ubuntu/macOS/Windows, plus the +hdf5 job) and both Rust jobs (including the new `cargo test` gate).

## Purpose

Enables GPU validation of the cudf-polars path on Google Colab: once `evlib==0.9.0` is on PyPI, `pip install evlib cudf-polars-cu12` on a Colab GPU runtime lets the Polars processing run with `collect(engine="gpu")`.
