### PR TITLE
fix: reader/codec robustness + real AEDAT 4.0 (DV) support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           - os: macos-latest  # ARM64 macOS (Apple Silicon)
             platform: macos
             arch: arm64
-            python-version: "3.10"
+            python-version: "3.13"
           - os: macos-latest
             platform: macos
             arch: arm64
@@ -83,7 +83,7 @@ jobs:
           - os: windows-latest
             platform: windows
             arch: x64
-            python-version: "3.10"
+            python-version: "3.13"
           - os: windows-latest
             platform: windows
             arch: x64
@@ -181,7 +181,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,14 +152,15 @@ jobs:
           fi
 
           # Build wheel with all features on Unix (HDF5 included via platform dependencies)
-          maturin build --release --features python,polars,arrow --interpreter python${{ matrix.python-version }} --out dist
+          # extension-module is required so the distributed wheel does not link libpython directly.
+          maturin build --release --features python,polars,arrow,extension-module --interpreter python${{ matrix.python-version }} --out dist
 
       - name: Build wheels (Windows)
         if: matrix.platform == 'windows'
         run: |
           .venv\Scripts\activate
           # Windows builds exclude HDF5 due to build complexity
-          maturin build --release --features python,polars --interpreter python --out dist
+          maturin build --release --features python,polars,extension-module --interpreter python --out dist
         env:
           CARGO_BUILD_TARGET: x86_64-pc-windows-msvc
 
@@ -241,7 +242,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --features python,polars,arrow --interpreter python${{ matrix.python-version }}
+          args: --release --features python,polars,arrow,extension-module --interpreter python${{ matrix.python-version }}
           rust-toolchain: nightly
           manylinux: 2014
           before-script-linux: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         features: [""]
         include:
           - os: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "hdf5-metno",
  "hdf5-metno-sys",
  "lazy_static",
+ "lz4_flex",
  "memmap2 0.5.10",
  "ndarray",
  "ndarray-rand",
@@ -1693,6 +1694,15 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -3776,6 +3786,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ pyo3-arrow     = { version = "0.10.1", optional = true }
 memmap2        = "0.5"
 lazy_static    = "1.4"
 byteorder      = "1.5"
+# LZ4 frame decompression for AEDAT 4.0 (DV framework) packet bodies
+lz4_flex       = { version = "0.11", default-features = false, features = ["frame"] }
 
 serde          = { version = "1.0", features = ["derive"] }
 serde_json     = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ harness = false
 [dependencies]
 # Python bindings (optional)
 numpy          = { version = "0.25.0", optional = true }
-pyo3           = { version = "0.25.1", features = ["extension-module"], optional = true }
+pyo3           = { version = "0.25.1", optional = true }
 pyo3-ffi       = { version = "0.25.1", optional = true }
 
 # Core data processing
@@ -107,6 +107,12 @@ default        = ["polars", "python", "arrow"]
 
 # Individual feature flags
 python         = ["dep:pyo3", "dep:pyo3-ffi", "dep:numpy", "dep:pyo3-polars"]
+# Opt-in PyO3 extension-module mode. Required ONLY for distributable wheels
+# (manylinux/macOS/Windows) so the .so does not link libpython directly.
+# Deliberately NOT in `default`: with it off, pyo3's build script links the
+# present libpython, which lets `cargo test` and `maturin develop` build and
+# run without any RUSTFLAGS hack.
+extension-module = ["pyo3/extension-module"]
 # cuda           = ["candle-core/cuda"]  # Removed with candle dependencies
 # metal          = ["candle-core/metal"]  # Removed with candle dependencies
 polars         = ["dep:polars"]

--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ maturin develop                    # default minimal build
 maturin develop --features hdf5    # opt-in HDF5 support (Linux/macOS)
 ```
 
+Distributable wheels are built with the opt-in `extension-module` feature, e.g.
+`maturin build --release --features python,polars,arrow,extension-module`. That
+feature is deliberately off by default so `cargo test` and `maturin develop`
+build and run without linking errors.
+
 HDF5 is opt-in on Linux/macOS and unavailable on Windows — use `h5py` directly
 for HDF5 I/O on Windows. Full details and platform-specific notes live in
 the [installation guide](https://tallamjr.github.io/evlib/getting-started/installation/).
@@ -191,10 +196,11 @@ Benchmarks and performance scripts live in [`benches/`](./benches).
 ## Development
 
 ```bash
-# Tests
-pytest                        # Python
+# Tests (both run directly, no special flags needed)
+pytest                        # Python (test suite only)
 cargo test                    # Rust
-pytest --markdown-docs docs/  # doc examples
+pytest --markdown-docs docs/  # doc examples (explicit)
+pytest --nbmake examples/     # example notebooks (explicit)
 
 # Formatting / linting
 black python/ tests/ examples/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,12 @@ include = [{ path = "rust-toolchain.toml", format = "sdist" }, { path = "dist", 
 # (nbmake notebooks) need extra deps and data, and CI invokes them explicitly
 # (`pytest --nbmake examples/`, `pytest --markdown-docs docs/`).
 testpaths = ["tests"]
+# Put the repo root on sys.path so tests/conftest.py can do package-qualified
+# imports (`from tests.hdf5_support import ...`) regardless of the working
+# directory. Without this, conftest import fails in CI ("No module named
+# 'tests'") because the repo root is only implicitly importable when pytest
+# happens to run from it.
+pythonpath = ["."]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,10 @@ strip = true
 include = [{ path = "rust-toolchain.toml", format = "sdist" }, { path = "dist", format = ["sdist", "wheel"]} ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "docs", "examples"]
+# Bare `pytest` runs the test suite only. docs (markdown-docs) and examples
+# (nbmake notebooks) need extra deps and data, and CI invokes them explicitly
+# (`pytest --nbmake examples/`, `pytest --markdown-docs docs/`).
+testpaths = ["tests"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name = "Tarek Allam", email = "t.allam.jr@gmail.com" },
 ]
 license = { file = "LICENSE.md" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
   "Environment :: Console",
   "Intended Audience :: Science/Research",
@@ -19,9 +19,9 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Rust",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Image Processing",

--- a/src/ev_formats/aedat4_reader.rs
+++ b/src/ev_formats/aedat4_reader.rs
@@ -1,0 +1,651 @@
+//! AEDAT 4.0 (iniVation DV framework) reader.
+//!
+//! Implements the real on-disk format produced by the DV software framework, as
+//! opposed to the invented "28-byte packet header" layout that the legacy
+//! `aedat_reader` carried. The wire format is, in order:
+//!
+//! 1. A fixed 14-byte version line: `#!AER-DAT4.0\r\n`.
+//! 2. A little-endian `u32` size prefix followed by an `IOHeader` FlatBuffer
+//!    (file identifier `IOHE`). The header carries the compression type, the
+//!    byte position of the trailing `FileDataTable`, and an XML `infoNode`
+//!    string describing every stream (id, type identifier, output name,
+//!    sensor resolution).
+//! 3. A sequence of packets. Each packet is an 8-byte `PacketHeader`
+//!    (`StreamID: i32`, `Size: i32`, both little-endian) followed by `Size`
+//!    bytes of body. The body is a size-prefixed `EventPacket` FlatBuffer
+//!    (file identifier `EVTS`), optionally LZ4-frame compressed.
+//!
+//! The `EventPacket` contains a vector of fixed 16-byte `Event` structs:
+//! `timestamp: i64` (microseconds) at byte 0, `x: i16` at byte 8, `y: i16` at
+//! byte 10, `polarity: bool` at byte 12 (remaining bytes are struct padding).
+//!
+//! Reference: `lib/dv-processing/include/dv-processing/io/reader.hpp` and the
+//! FlatBuffer schemas under `lib/dv-processing/include/dv-processing/`.
+//!
+//! Only the FlatBuffer fields evlib actually consumes are parsed; the parsing is
+//! hand-written against the (fixed, simple) schemas rather than relying on
+//! `flatc`-generated code, to avoid coupling the crate to a specific
+//! `flatbuffers` runtime version.
+
+use crate::ev_formats::aedat_reader::{AedatConfig, AedatError, AedatMetadata, AedatVersion};
+use crate::ev_formats::dataframe_builder::EventDataFrameBuilder;
+use crate::ev_formats::EventFormat;
+use polars::prelude::DataFrame;
+use std::io::Read;
+
+/// Length of the AEDAT 4.0 version line `#!AER-DAT4.0\r\n`.
+const AEDAT4_VERSION_LENGTH: usize = 14;
+/// The exact version line expected at the start of an AEDAT 4.0 file.
+pub const AEDAT4_VERSION_LINE: &[u8] = b"#!AER-DAT4.0\r\n";
+/// FlatBuffer file identifier for the `EventPacket` type.
+const EVENT_PACKET_IDENTIFIER: &[u8; 4] = b"EVTS";
+/// Size in bytes of a single `Event` struct (8 + 2 + 2 + 1 + 3 padding).
+const EVENT_STRUCT_SIZE: usize = 16;
+/// Size in bytes of a `PacketHeader` (`StreamID: i32` + `Size: i32`).
+const PACKET_HEADER_SIZE: usize = 8;
+
+/// Compression type used for packet bodies (mirrors the DV `CompressionType` enum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompressionType {
+    None,
+    Lz4,
+    Zstd,
+}
+
+impl CompressionType {
+    fn from_enum(value: i32) -> Result<Self, AedatError> {
+        match value {
+            // NONE
+            0 => Ok(CompressionType::None),
+            // LZ4 and LZ4_HIGH both decode with the same LZ4 frame decoder.
+            1 | 2 => Ok(CompressionType::Lz4),
+            // ZSTD and ZSTD_HIGH both decode with the same Zstd decoder.
+            3 | 4 => Ok(CompressionType::Zstd),
+            other => Err(AedatError::CorruptedHeader(format!(
+                "Unknown AEDAT 4.0 compression type: {other}"
+            ))),
+        }
+    }
+}
+
+/// Description of one stream extracted from the IOHeader's XML info node.
+#[derive(Debug, Clone)]
+struct StreamInfo {
+    id: i32,
+    type_identifier: String,
+    size_x: Option<u16>,
+    size_y: Option<u16>,
+}
+
+/// Parsed IOHeader contents.
+#[derive(Debug)]
+struct IoHeader {
+    compression: CompressionType,
+    /// Byte position of the trailing FileDataTable, or `-1` if unknown. Packets
+    /// occupy the bytes between the IOHeader and this position.
+    data_table_position: i64,
+    streams: Vec<StreamInfo>,
+}
+
+/// Read the entire AEDAT 4.0 file into events using the DV framework layout.
+///
+/// `data` must be the full file contents (the version line is re-validated here).
+pub fn read_aedat_4_0(
+    data: &[u8],
+    config: &AedatConfig,
+) -> Result<(DataFrame, AedatMetadata), AedatError> {
+    if data.len() < AEDAT4_VERSION_LENGTH || &data[..AEDAT4_VERSION_LENGTH] != AEDAT4_VERSION_LINE {
+        return Err(AedatError::InvalidVersion(
+            "AEDAT 4.0: missing or invalid `#!AER-DAT4.0` version line".to_string(),
+        ));
+    }
+
+    // IOHeader: u32 LE size prefix at offset 14, then that many bytes of FlatBuffer.
+    let header_size_offset = AEDAT4_VERSION_LENGTH;
+    let io_header_size = read_u32_le(data, header_size_offset)? as usize;
+    let io_header_start = header_size_offset + 4;
+    let io_header_end = io_header_start
+        .checked_add(io_header_size)
+        .ok_or_else(|| AedatError::CorruptedHeader("IOHeader size overflow".to_string()))?;
+    if io_header_end > data.len() {
+        return Err(AedatError::InsufficientData {
+            expected: io_header_end,
+            actual: data.len(),
+        });
+    }
+    let io_header = parse_io_header(&data[io_header_start..io_header_end])?;
+
+    // Determine which stream ids carry event data (type identifier "EVTS").
+    let event_streams: Vec<&StreamInfo> = io_header
+        .streams
+        .iter()
+        .filter(|s| s.type_identifier == "EVTS")
+        .collect();
+
+    let mut metadata = AedatMetadata {
+        version: Some(AedatVersion::V4_0),
+        ..Default::default()
+    };
+    metadata.header_size = io_header_end as u64;
+    // Record sensor resolution from the first event stream that declares one.
+    for stream in &event_streams {
+        if let (Some(w), Some(h)) = (stream.size_x, stream.size_y) {
+            metadata.sensor_resolution = Some((w, h));
+            break;
+        }
+    }
+
+    let event_stream_ids: std::collections::HashSet<i32> =
+        event_streams.iter().map(|s| s.id).collect();
+
+    let mut builder = EventDataFrameBuilder::new(EventFormat::AEDAT4, 100_000);
+    let mut total_events = 0usize;
+
+    // Packets occupy the bytes between the IOHeader and the trailing
+    // FileDataTable. Use dataTablePosition as the upper bound when present so we
+    // never misread the FileDataTable region as a packet header.
+    let packet_region_end = match io_header.data_table_position {
+        pos if pos >= 0 && (pos as usize) <= data.len() => pos as usize,
+        _ => data.len(),
+    };
+
+    // Iterate packets sequentially from the end of the IOHeader to the data table.
+    let mut cursor = io_header_end;
+    while cursor + PACKET_HEADER_SIZE <= packet_region_end {
+        let stream_id = read_i32_le(data, cursor)?;
+        let packet_size = read_i32_le(data, cursor + 4)?;
+        if packet_size < 0 {
+            return Err(AedatError::InvalidBinaryData {
+                offset: cursor as u64,
+                message: format!("Negative packet size {packet_size}"),
+            });
+        }
+        let body_start = cursor + PACKET_HEADER_SIZE;
+        let body_end = body_start
+            .checked_add(packet_size as usize)
+            .ok_or_else(|| AedatError::CorruptedHeader("Packet size overflow".to_string()))?;
+        if body_end > packet_region_end {
+            // Truncated trailing packet (or we hit the FileDataTable region). Stop.
+            break;
+        }
+
+        if event_stream_ids.contains(&stream_id) {
+            let raw_body = &data[body_start..body_end];
+            let decompressed = decompress(raw_body, io_header.compression)?;
+            let added = parse_event_packet(&decompressed, config, &mut builder, total_events)?;
+            total_events += added;
+        }
+
+        if let Some(max_events) = config.max_events {
+            if total_events >= max_events {
+                break;
+            }
+        }
+
+        cursor = body_end;
+    }
+
+    metadata.event_count = Some(total_events);
+
+    let events = builder.build().map_err(|e| AedatError::InvalidBinaryData {
+        offset: 0,
+        message: format!("Failed to build DataFrame: {e}"),
+    })?;
+
+    Ok((events, metadata))
+}
+
+/// Decompress a packet body according to the file's compression type.
+fn decompress(body: &[u8], compression: CompressionType) -> Result<Vec<u8>, AedatError> {
+    match compression {
+        CompressionType::None => Ok(body.to_vec()),
+        CompressionType::Lz4 => {
+            let mut decoder = lz4_flex::frame::FrameDecoder::new(body);
+            let mut out = Vec::new();
+            decoder
+                .read_to_end(&mut out)
+                .map_err(|e| AedatError::InvalidBinaryData {
+                    offset: 0,
+                    message: format!("LZ4 frame decompression failed: {e}"),
+                })?;
+            Ok(out)
+        }
+        CompressionType::Zstd => Err(AedatError::CorruptedHeader(
+            "AEDAT 4.0 Zstd-compressed packets are not yet supported".to_string(),
+        )),
+    }
+}
+
+/// Parse a size-prefixed `EventPacket` FlatBuffer, appending events to the builder.
+///
+/// Returns the number of events appended.
+fn parse_event_packet(
+    buffer: &[u8],
+    config: &AedatConfig,
+    builder: &mut EventDataFrameBuilder,
+    events_so_far: usize,
+) -> Result<usize, AedatError> {
+    // Size-prefixed root: first 4 bytes are a u32 prefix; the FlatBuffer root
+    // begins immediately after it.
+    if buffer.len() < 8 {
+        return Err(AedatError::InvalidBinaryData {
+            offset: 0,
+            message: "EventPacket buffer too small".to_string(),
+        });
+    }
+    let root_base = 4usize;
+
+    // The file identifier sits at bytes [root_base + 4 .. root_base + 8].
+    if buffer.len() >= root_base + 8 {
+        let ident = &buffer[root_base + 4..root_base + 8];
+        if ident != EVENT_PACKET_IDENTIFIER {
+            return Err(AedatError::InvalidBinaryData {
+                offset: 0,
+                message: format!("Unexpected FlatBuffer identifier {ident:?}, expected EVTS"),
+            });
+        }
+    }
+
+    // Root table offset (u32 LE relative to root_base).
+    let root_table_offset = read_u32_le(buffer, root_base)? as usize;
+    let root_table = root_base + root_table_offset;
+
+    // vtable: signed offset stored at the start of the table; vtable = table - soffset.
+    let soffset = read_i32_le(buffer, root_table)?;
+    let vtable = (root_table as i64 - soffset as i64) as usize;
+    let vtable_size = read_u16_le(buffer, vtable)? as usize;
+
+    // EventPacket has a single field `elements` at vtable slot offset 4.
+    // The vtable layout: [vtable_size(u16), table_size(u16), field0_voffset(u16), ...].
+    let elements_slot = vtable + 4;
+    if elements_slot + 2 > vtable + vtable_size {
+        // Field not present; empty packet.
+        return Ok(0);
+    }
+    let field_voffset = read_u16_le(buffer, elements_slot)? as usize;
+    if field_voffset == 0 {
+        return Ok(0);
+    }
+
+    // Field stores a u32 offset (relative to its own position) to the vector.
+    let field_pos = root_table + field_voffset;
+    let vector_offset = read_u32_le(buffer, field_pos)? as usize;
+    let vector_pos = field_pos + vector_offset;
+
+    // Vector layout: u32 length, then `length` inline Event structs.
+    let count = read_u32_le(buffer, vector_pos)? as usize;
+    let elements_start = vector_pos + 4;
+    let elements_end = elements_start
+        .checked_add(count.checked_mul(EVENT_STRUCT_SIZE).ok_or_else(|| {
+            AedatError::CorruptedHeader("EventPacket element count overflow".to_string())
+        })?)
+        .ok_or_else(|| {
+            AedatError::CorruptedHeader("EventPacket vector range overflow".to_string())
+        })?;
+    if elements_end > buffer.len() {
+        return Err(AedatError::InsufficientData {
+            expected: elements_end,
+            actual: buffer.len(),
+        });
+    }
+
+    let mut appended = 0usize;
+    for i in 0..count {
+        let base = elements_start + i * EVENT_STRUCT_SIZE;
+        let timestamp = read_i64_le(buffer, base)?;
+        let x = read_i16_le(buffer, base + 8)?;
+        let y = read_i16_le(buffer, base + 10)?;
+        let polarity = buffer[base + 12] != 0;
+
+        if x < 0 || y < 0 {
+            if config.skip_invalid_events {
+                continue;
+            }
+            return Err(AedatError::InvalidBinaryData {
+                offset: base as u64,
+                message: format!("Negative event coordinate x={x}, y={y}"),
+            });
+        }
+        let xu = x as u16;
+        let yu = y as u16;
+
+        if config.validate_coordinates {
+            if let Some((max_x, max_y)) = config.max_resolution {
+                if xu >= max_x || yu >= max_y {
+                    if config.skip_invalid_events {
+                        continue;
+                    }
+                    return Err(AedatError::CoordinateOutOfBounds {
+                        event_index: events_so_far + appended,
+                        x: xu,
+                        y: yu,
+                        max_x,
+                        max_y,
+                    });
+                }
+            }
+        }
+
+        // DV timestamps are exact integer microseconds (frequently absolute epoch
+        // microseconds), so store them verbatim and bypass the magnitude heuristic.
+        builder.add_event_microseconds(xu, yu, timestamp, polarity);
+        appended += 1;
+    }
+
+    Ok(appended)
+}
+
+/// Parse the IOHeader FlatBuffer, extracting compression and the stream info.
+fn parse_io_header(buffer: &[u8]) -> Result<IoHeader, AedatError> {
+    // Non-size-prefixed root: u32 offset at byte 0.
+    let root_table_offset = read_u32_le(buffer, 0)? as usize;
+    let root_table = root_table_offset;
+
+    let soffset = read_i32_le(buffer, root_table)?;
+    let vtable = (root_table as i64 - soffset as i64) as usize;
+    let vtable_size = read_u16_le(buffer, vtable)? as usize;
+
+    // IOHeader fields: 0 compression (i32), 1 dataTablePosition (i64), 2 infoNode (string).
+    // vtable slots start at vtable+4.
+    let compression = {
+        let slot = vtable + 4;
+        if slot + 2 <= vtable + vtable_size {
+            let voffset = read_u16_le(buffer, slot)? as usize;
+            if voffset != 0 {
+                CompressionType::from_enum(read_i32_le(buffer, root_table + voffset)?)?
+            } else {
+                CompressionType::None
+            }
+        } else {
+            CompressionType::None
+        }
+    };
+
+    let data_table_position = {
+        let slot = vtable + 6; // field index 1 -> vtable offset 4 + 1*2
+        if slot + 2 <= vtable + vtable_size {
+            let voffset = read_u16_le(buffer, slot)? as usize;
+            if voffset != 0 {
+                read_i64_le(buffer, root_table + voffset)?
+            } else {
+                -1
+            }
+        } else {
+            -1
+        }
+    };
+
+    let info_node = {
+        let slot = vtable + 8; // field index 2 -> vtable offset 4 + 2*2
+        if slot + 2 <= vtable + vtable_size {
+            let voffset = read_u16_le(buffer, slot)? as usize;
+            if voffset != 0 {
+                let field_pos = root_table + voffset;
+                let str_offset = read_u32_le(buffer, field_pos)? as usize;
+                let str_pos = field_pos + str_offset;
+                let str_len = read_u32_le(buffer, str_pos)? as usize;
+                let str_start = str_pos + 4;
+                let str_end = str_start.checked_add(str_len).ok_or_else(|| {
+                    AedatError::CorruptedHeader("infoNode string range overflow".to_string())
+                })?;
+                if str_end > buffer.len() {
+                    return Err(AedatError::InsufficientData {
+                        expected: str_end,
+                        actual: buffer.len(),
+                    });
+                }
+                String::from_utf8_lossy(&buffer[str_start..str_end]).into_owned()
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        }
+    };
+
+    let streams = parse_info_node(&info_node);
+
+    Ok(IoHeader {
+        compression,
+        data_table_position,
+        streams,
+    })
+}
+
+/// Extract per-stream metadata from the IOHeader's XML `infoNode`.
+///
+/// The XML is a DV configuration tree. Each stream is a `<node name="<id>">`
+/// directly under the `outInfo` node, carrying `typeIdentifier` and
+/// `originalOutputName` attributes plus an `info` child with `sizeX`/`sizeY`.
+/// A lightweight scan is sufficient and avoids pulling in an XML dependency.
+fn parse_info_node(xml: &str) -> Vec<StreamInfo> {
+    let mut streams = Vec::new();
+
+    // Split into <node ...> opening tags and walk them in order. We track the
+    // most recent numeric stream id so that the `info` child's sizeX/sizeY can
+    // be attributed to it.
+    let mut current: Option<StreamInfo> = None;
+
+    for segment in xml.split('<') {
+        let segment = segment.trim_start();
+        if let Some(rest) = segment.strip_prefix("node ") {
+            // A node opening tag. Extract its name attribute.
+            if let Some(name) = extract_attr_value(rest, "name") {
+                if let Ok(id) = name.parse::<i32>() {
+                    // Numeric node name == stream id. Push any pending stream first.
+                    if let Some(stream) = current.take() {
+                        streams.push(stream);
+                    }
+                    current = Some(StreamInfo {
+                        id,
+                        type_identifier: String::new(),
+                        size_x: None,
+                        size_y: None,
+                    });
+                }
+            }
+        } else if let Some(rest) = segment.strip_prefix("attr ") {
+            // An attribute entry: <attr key="..." type="...">value</attr>.
+            if let (Some(key), Some(value)) =
+                (extract_attr_value(rest, "key"), extract_tag_text(segment))
+            {
+                if let Some(stream) = current.as_mut() {
+                    match key.as_str() {
+                        "typeIdentifier" => stream.type_identifier = value,
+                        "sizeX" => stream.size_x = value.parse().ok(),
+                        "sizeY" => stream.size_y = value.parse().ok(),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    if let Some(stream) = current.take() {
+        streams.push(stream);
+    }
+
+    streams
+}
+
+/// Extract the value of `key="..."` from an attribute fragment.
+fn extract_attr_value(fragment: &str, key: &str) -> Option<String> {
+    let needle = format!("{key}=\"");
+    let start = fragment.find(&needle)? + needle.len();
+    let end = fragment[start..].find('"')? + start;
+    Some(fragment[start..end].to_string())
+}
+
+/// Extract the text content of a `<attr ...>text</attr>` fragment.
+fn extract_tag_text(segment: &str) -> Option<String> {
+    let close = segment.find('>')?;
+    let after = &segment[close + 1..];
+    // Text runs until the start of the closing tag (the next `<`, which split
+    // already removed, so the remainder of this segment is the text).
+    Some(after.trim().to_string())
+}
+
+// --- Little-endian primitive readers with bounds checks -------------------
+
+fn read_u16_le(data: &[u8], offset: usize) -> Result<u16, AedatError> {
+    let end = offset + 2;
+    if end > data.len() {
+        return Err(AedatError::InsufficientData {
+            expected: end,
+            actual: data.len(),
+        });
+    }
+    Ok(u16::from_le_bytes([data[offset], data[offset + 1]]))
+}
+
+fn read_i16_le(data: &[u8], offset: usize) -> Result<i16, AedatError> {
+    Ok(read_u16_le(data, offset)? as i16)
+}
+
+fn read_u32_le(data: &[u8], offset: usize) -> Result<u32, AedatError> {
+    let end = offset + 4;
+    if end > data.len() {
+        return Err(AedatError::InsufficientData {
+            expected: end,
+            actual: data.len(),
+        });
+    }
+    Ok(u32::from_le_bytes([
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+    ]))
+}
+
+fn read_i32_le(data: &[u8], offset: usize) -> Result<i32, AedatError> {
+    Ok(read_u32_le(data, offset)? as i32)
+}
+
+fn read_i64_le(data: &[u8], offset: usize) -> Result<i64, AedatError> {
+    let end = offset + 8;
+    if end > data.len() {
+        return Err(AedatError::InsufficientData {
+            expected: end,
+            actual: data.len(),
+        });
+    }
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&data[offset..end]);
+    Ok(i64::from_le_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Reference event counts and first events, cross-checked against
+    /// dv-processing 2.0.3 (`MonoCameraRecording`).
+    struct Sample {
+        path: &'static str,
+        events: usize,
+        first_x: u16,
+        first_y: u16,
+        first_polarity: bool,
+        first_timestamp: i64,
+        max_x: u16,
+        max_y: u16,
+    }
+
+    const SAMPLES: &[Sample] = &[
+        Sample {
+            path: "lib/dv-processing/tests/io/test_files/sample_data.aedat4",
+            events: 9193,
+            first_x: 56,
+            first_y: 16,
+            first_polarity: true,
+            first_timestamp: 1_663_249_605_734_020,
+            max_x: 346,
+            max_y: 260,
+        },
+        Sample {
+            path: "lib/dv-processing/python/tests/data/sample_data.aedat4",
+            events: 9408,
+            first_x: 64,
+            first_y: 48,
+            first_polarity: true,
+            first_timestamp: 1,
+            max_x: 640,
+            max_y: 480,
+        },
+        Sample {
+            path: "lib/dv-processing/tests/io/test_files/test-minimal.aedat4",
+            events: 255_283,
+            first_x: 185,
+            first_y: 168,
+            first_polarity: false,
+            first_timestamp: 1_631_717_221_674_515,
+            max_x: 640,
+            max_y: 480,
+        },
+    ];
+
+    fn read_first_event(df: &DataFrame) -> (u16, u16, i64, i8) {
+        let x = df.column("x").unwrap().i16().unwrap();
+        let y = df.column("y").unwrap().i16().unwrap();
+        let t = df.column("t").unwrap().duration().unwrap();
+        let p = df.column("polarity").unwrap().i8().unwrap();
+        (
+            x.get(0).unwrap() as u16,
+            y.get(0).unwrap() as u16,
+            t.get(0).unwrap(),
+            p.get(0).unwrap(),
+        )
+    }
+
+    #[test]
+    fn reads_real_dv_samples() {
+        for sample in SAMPLES {
+            if !Path::new(sample.path).exists() {
+                eprintln!("skipping absent sample {}", sample.path);
+                continue;
+            }
+            let data = std::fs::read(sample.path).unwrap();
+            // Use generous bounds so the loosely-bounded resolution does not
+            // reject legitimate events; the per-sample assertions below verify
+            // coordinates stay within sensor bounds.
+            let config = AedatConfig {
+                validate_timestamps: false,
+                validate_coordinates: true,
+                validate_polarity: false,
+                skip_invalid_events: false,
+                max_events: None,
+                max_resolution: Some((sample.max_x, sample.max_y)),
+            };
+            let (df, metadata) = read_aedat_4_0(&data, &config).unwrap();
+
+            assert_eq!(metadata.version, Some(AedatVersion::V4_0));
+            assert_eq!(
+                df.height(),
+                sample.events,
+                "event count mismatch for {}",
+                sample.path
+            );
+
+            let (fx, fy, ft, fp) = read_first_event(&df);
+            assert_eq!(fx, sample.first_x, "first x for {}", sample.path);
+            assert_eq!(fy, sample.first_y, "first y for {}", sample.path);
+            assert_eq!(ft, sample.first_timestamp, "first ts for {}", sample.path);
+            let expected_pol: i8 = if sample.first_polarity { 1 } else { -1 };
+            assert_eq!(fp, expected_pol, "first polarity for {}", sample.path);
+
+            // All coordinates within sensor bounds; polarity strictly in {-1, 1}.
+            let xs = df.column("x").unwrap().i16().unwrap();
+            let ys = df.column("y").unwrap().i16().unwrap();
+            let ps = df.column("polarity").unwrap().i8().unwrap();
+            for i in 0..df.height() {
+                let xv = xs.get(i).unwrap();
+                let yv = ys.get(i).unwrap();
+                let pv = ps.get(i).unwrap();
+                assert!(xv >= 0 && (xv as u16) < sample.max_x);
+                assert!(yv >= 0 && (yv as u16) < sample.max_y);
+                assert!(pv == 1 || pv == -1, "polarity {pv} not in {{-1,1}}");
+            }
+        }
+    }
+}

--- a/src/ev_formats/aedat_reader.rs
+++ b/src/ev_formats/aedat_reader.rs
@@ -406,21 +406,26 @@ impl AedatReader {
                                                // Note: For DVS128, coordinates are max 128x128, so 7 bits each is sufficient
                                                // The coordinate system has (0,0) at lower left, but we convert to upper left
                                                // by inverting y coordinate if sensor resolution is known
-                                               // Validate coordinates and timestamp before adding to builder
-                if self.config.validate_timestamps {
-                    if x > 127 || y > 127 {
-                        if self.config.skip_invalid_events {
-                            continue;
-                        } else {
-                            return Err(AedatError::CoordinateOutOfBounds {
-                                event_index,
-                                x,
-                                y,
-                                max_x: 127,
-                                max_y: 127,
-                            });
+                                               // Validate coordinates against the configured resolution
+                if self.config.validate_coordinates {
+                    if let Some((max_x, max_y)) = self.config.max_resolution {
+                        if x >= max_x || y >= max_y {
+                            if self.config.skip_invalid_events {
+                                continue;
+                            } else {
+                                return Err(AedatError::CoordinateOutOfBounds {
+                                    event_index,
+                                    x,
+                                    y,
+                                    max_x,
+                                    max_y,
+                                });
+                            }
                         }
                     }
+                }
+                // Validate timestamp monotonicity before adding to builder
+                if self.config.validate_timestamps {
                     let current_timestamp = timestamp as f64;
                     if current_timestamp < prev_timestamp {
                         if self.config.skip_invalid_events {
@@ -560,7 +565,25 @@ impl AedatReader {
                 let x = (address >> 1) & 0x7FFF; // 15 bits: 0x7FFF = 0111 1111 1111 1111
                                                  // Extract y coordinate from bits 16-30 (up to 15 bits)
                 let y = (address >> 16) & 0x7FFF; // 15 bits: 0x7FFF = 0111 1111 1111 1111
-                                                  // Validate coordinates and timestamp before adding to builder
+                                                  // Validate coordinates against the configured resolution
+                if self.config.validate_coordinates {
+                    if let Some((max_x, max_y)) = self.config.max_resolution {
+                        if x >= max_x as u32 || y >= max_y as u32 {
+                            if self.config.skip_invalid_events {
+                                continue;
+                            } else {
+                                return Err(AedatError::CoordinateOutOfBounds {
+                                    event_index,
+                                    x: x as u16,
+                                    y: y as u16,
+                                    max_x,
+                                    max_y,
+                                });
+                            }
+                        }
+                    }
+                }
+                // Validate timestamp monotonicity before adding to builder
                 if self.config.validate_timestamps {
                     let current_timestamp = timestamp as f64;
                     if current_timestamp < prev_timestamp {
@@ -714,7 +737,25 @@ impl AedatReader {
                 let y = (address >> 2) & 0x7FFF; // 15 bits: 0x7FFF = 0111 1111 1111 1111
                                                  // Extract x coordinate from bits 17-31 (up to 15 bits)
                 let x = (address >> 17) & 0x7FFF; // 15 bits: 0x7FFF = 0111 1111 1111 1111
-                                                  // Validate coordinates and timestamp before adding to builder
+                                                  // Validate coordinates against the configured resolution
+                if self.config.validate_coordinates {
+                    if let Some((max_x, max_y)) = self.config.max_resolution {
+                        if x >= max_x as u32 || y >= max_y as u32 {
+                            if self.config.skip_invalid_events {
+                                continue;
+                            } else {
+                                return Err(AedatError::CoordinateOutOfBounds {
+                                    event_index,
+                                    x: x as u16,
+                                    y: y as u16,
+                                    max_x,
+                                    max_y,
+                                });
+                            }
+                        }
+                    }
+                }
+                // Validate timestamp monotonicity before adding to builder
                 if self.config.validate_timestamps {
                     let current_timestamp = timestamp as f64;
                     if current_timestamp < prev_timestamp {
@@ -919,7 +960,7 @@ impl AedatReader {
             });
         }
         // Parse polarity events (8 bytes each in DV format)
-        for chunk in buffer.chunks_exact(8) {
+        for (event_index, chunk) in buffer.chunks_exact(8).enumerate() {
             let timestamp = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
             let x = u16::from_le_bytes([chunk[4], chunk[5]]);
             let y = u16::from_le_bytes([chunk[6], chunk[7]]);
@@ -933,10 +974,23 @@ impl AedatReader {
             let polarity = (y & 0x8000) != 0;
             // Extract y coordinate by masking out polarity bit
             let y_clean = y & 0x7FFF; // Remove polarity bit (bit 15)
-                                      // Validate coordinates are within reasonable bounds
-            if x >= 8192 || y_clean >= 8192 {
-                // Skip events with unreasonable coordinates (likely corrupted)
-                continue;
+                                      // Validate coordinates against the configured resolution
+            if self.config.validate_coordinates {
+                if let Some((max_x, max_y)) = self.config.max_resolution {
+                    if x >= max_x || y_clean >= max_y {
+                        if self.config.skip_invalid_events {
+                            continue;
+                        } else {
+                            return Err(AedatError::CoordinateOutOfBounds {
+                                event_index,
+                                x,
+                                y: y_clean,
+                                max_x,
+                                max_y,
+                            });
+                        }
+                    }
+                }
             }
             events.push((x, y_clean, timestamp as f64, polarity));
         }
@@ -1238,8 +1292,6 @@ mod tests {
         assert_eq!(events.height(), 2); // Both events should be read
     }
     /// Test coordinate bounds validation
-    #[ignore = "pre-existing AEDAT reader defect: max_resolution bounds are not enforced so \
-                CoordinateOutOfBounds is never returned; unrelated to the API port, tracked separately"]
     #[test]
     fn test_coordinate_bounds_validation() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/ev_formats/aedat_reader.rs
+++ b/src/ev_formats/aedat_reader.rs
@@ -230,7 +230,9 @@ impl AedatReader {
             });
         }
         // Check for version magic bytes - order matters!
-        if buffer.starts_with(b"AEDAT4") {
+        // Real DV-framework AEDAT 4.0 files start with `#!AER-DAT4.0\r\n`, so
+        // the specific 4.0 line must be tested before the generic 3.x fallback.
+        if buffer.starts_with(b"#!AER-DAT4.0") || buffer.starts_with(b"AEDAT4") {
             return Ok(AedatVersion::V4_0);
         }
         if buffer.starts_with(b"#!AER-DAT2.0") {
@@ -780,221 +782,18 @@ impl AedatReader {
             })
         }
     }
-    /// Read AEDAT 4.0 format
+    /// Read AEDAT 4.0 format (DV framework: FlatBuffer IOHeader + LZ4 packets).
+    ///
+    /// Delegates to [`crate::ev_formats::aedat4_reader`], which implements the
+    /// real DV on-disk layout. The whole file is read into memory because the
+    /// format is random-access (packet bodies are size-prefixed FlatBuffers and
+    /// a trailing FileDataTable indexes them); the streaming/chunked path is
+    /// reserved for the linear binary AEDAT 1.x/2.0/3.1 formats above.
     fn read_aedat_4_0(&self, file: &mut File) -> Result<(DataFrame, AedatMetadata), AedatError> {
-        let mut metadata = AedatMetadata {
-            version: Some(AedatVersion::V4_0),
-            ..Default::default()
-        };
-        // Parse header
         file.seek(SeekFrom::Start(0))?;
-        let header_size = self.parse_aedat_4_0_header(file, &mut metadata)?;
-        // Read binary event data with DV framework packet structure
-        file.seek(SeekFrom::Start(header_size))?;
-        let events = self.read_aedat_4_0_events(file)?;
-        metadata.event_count = Some(events.height());
-        Ok((events, metadata))
-    }
-    /// Parse AEDAT 4.0 header (DV framework)
-    fn parse_aedat_4_0_header(
-        &self,
-        file: &mut File,
-        metadata: &mut AedatMetadata,
-    ) -> Result<u64, AedatError> {
-        file.seek(SeekFrom::Start(0))?;
-        let mut buffer = Vec::new();
-        let mut temp_buffer = [0u8; 1024];
-        let mut header_size = 0u64;
-        let mut line_index = 0;
-        // Read file in chunks to find header end
-        loop {
-            let bytes_read = file.read(&mut temp_buffer)?;
-            if bytes_read == 0 {
-                break;
-            }
-            buffer.extend_from_slice(&temp_buffer[..bytes_read]);
-            // Look for header end (look for first non-comment line after AEDAT4)
-            let header_str = String::from_utf8_lossy(&buffer);
-            let mut found_header_end = false;
-            let mut byte_pos = 0;
-            for line in header_str.lines() {
-                if line.starts_with("AEDAT4") {
-                    byte_pos += line.len() + 1; // +1 for newline
-                    continue;
-                }
-                if line.starts_with('#') {
-                    byte_pos += line.len() + 1; // +1 for newline
-                    continue;
-                }
-                if line.trim().is_empty() {
-                    byte_pos += line.len() + 1; // +1 for newline
-                    continue;
-                }
-                // Found non-comment, non-empty line - this is the start of data
-                header_size = byte_pos as u64;
-                found_header_end = true;
-                break;
-            }
-            if found_header_end {
-                break;
-            }
-            if bytes_read < 1024 {
-                header_size = buffer.len() as u64;
-                break;
-            }
-        }
-        // Parse header lines
-        let header_str = String::from_utf8_lossy(&buffer[..header_size as usize]);
-        for line in header_str.lines() {
-            if line.starts_with("AEDAT4") {
-                continue; // Skip the format identifier
-            }
-            if line.starts_with('#') {
-                // Parse DV framework header information
-                if line.contains("sizeX") {
-                    if let Some(width) = self.extract_number_from_line(line) {
-                        metadata.sensor_resolution =
-                            Some((width, metadata.sensor_resolution.unwrap_or((0, 0)).1));
-                    }
-                } else if line.contains("sizeY") {
-                    if let Some(height) = self.extract_number_from_line(line) {
-                        metadata.sensor_resolution =
-                            Some((metadata.sensor_resolution.unwrap_or((0, 0)).0, height));
-                    }
-                }
-                metadata
-                    .properties
-                    .insert(format!("header_line_{line_index}"), line.to_string());
-                line_index += 1;
-            } else {
-                // End of header
-                break;
-            }
-        }
-        metadata.header_size = header_size;
-        Ok(header_size)
-    }
-    /// Read AEDAT 4.0 events (DV framework with 28-byte packet headers)
-    fn read_aedat_4_0_events(&self, file: &mut File) -> Result<DataFrame, AedatError> {
-        {
-            let mut builder = EventDataFrameBuilder::new(EventFormat::AEDAT1, 100_000);
-            let mut event_index = 0;
-            let mut prev_timestamp = 0.0;
-            loop {
-                if let Some(max_events) = self.config.max_events {
-                    if event_index >= max_events {
-                        break;
-                    }
-                }
-                // Read packet header (28 bytes)
-                let mut packet_header = [0u8; 28];
-                let bytes_read = file.read(&mut packet_header)?;
-                if bytes_read == 0 {
-                    break; // EOF
-                }
-                if bytes_read != 28 {
-                    if self.config.skip_invalid_events {
-                        continue;
-                    } else {
-                        return Err(AedatError::InsufficientData {
-                            expected: 28,
-                            actual: bytes_read,
-                        });
-                    }
-                }
-                // Parse packet header to determine packet type and size
-                let packet_type = u16::from_le_bytes([packet_header[0], packet_header[1]]);
-                let packet_size = u32::from_le_bytes([
-                    packet_header[4],
-                    packet_header[5],
-                    packet_header[6],
-                    packet_header[7],
-                ]);
-                // Only process polarity event packets (type 1)
-                if packet_type == 1 {
-                    let packet_events =
-                        self.read_aedat_4_0_packet_events(file, packet_size as usize)?;
-                    for (x, y, timestamp, polarity) in packet_events {
-                        // Validate coordinates and timestamp before adding to builder
-                        if self.config.validate_timestamps {
-                            if timestamp < prev_timestamp {
-                                if self.config.skip_invalid_events {
-                                    continue;
-                                } else {
-                                    return Err(AedatError::TimestampMonotonicityViolation {
-                                        event_index,
-                                        prev_timestamp,
-                                        curr_timestamp: timestamp,
-                                    });
-                                }
-                            }
-                            prev_timestamp = timestamp;
-                        }
-                        builder.add_event(x, y, timestamp, polarity);
-                        event_index += 1;
-                    }
-                } else {
-                    // Skip non-polarity packets
-                    file.seek(SeekFrom::Current(packet_size as i64))?;
-                }
-            }
-            builder.build().map_err(|e| AedatError::InvalidBinaryData {
-                offset: 0,
-                message: format!("Failed to build DataFrame: {}", e),
-            })
-        }
-    }
-    /// Read events from AEDAT 4.0 packet
-    fn read_aedat_4_0_packet_events(
-        &self,
-        file: &mut File,
-        packet_size: usize,
-    ) -> Result<Vec<(u16, u16, f64, bool)>, AedatError> {
-        let mut events = Vec::new();
-        let mut buffer = vec![0u8; packet_size];
-        let bytes_read = file.read(&mut buffer)?;
-        if bytes_read != packet_size {
-            return Err(AedatError::InsufficientData {
-                expected: packet_size,
-                actual: bytes_read,
-            });
-        }
-        // Parse polarity events (8 bytes each in DV format)
-        for (event_index, chunk) in buffer.chunks_exact(8).enumerate() {
-            let timestamp = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            let x = u16::from_le_bytes([chunk[4], chunk[5]]);
-            let y = u16::from_le_bytes([chunk[6], chunk[7]]);
-            // AEDAT 4.0 DV framework format:
-            // - Timestamp: 32-bit microsecond timestamp
-            // - X coordinate: 16-bit value (0-65535)
-            // - Y coordinate: 16-bit value with MSB encoding polarity
-            //   - Bit 15: Polarity (1 = ON, 0 = OFF)
-            //   - Bits 0-14: Y coordinate (0-32767)
-            // Extract polarity from MSB of y
-            let polarity = (y & 0x8000) != 0;
-            // Extract y coordinate by masking out polarity bit
-            let y_clean = y & 0x7FFF; // Remove polarity bit (bit 15)
-                                      // Validate coordinates against the configured resolution
-            if self.config.validate_coordinates {
-                if let Some((max_x, max_y)) = self.config.max_resolution {
-                    if x >= max_x || y_clean >= max_y {
-                        if self.config.skip_invalid_events {
-                            continue;
-                        } else {
-                            return Err(AedatError::CoordinateOutOfBounds {
-                                event_index,
-                                x,
-                                y: y_clean,
-                                max_x,
-                                max_y,
-                            });
-                        }
-                    }
-                }
-            }
-            events.push((x, y_clean, timestamp as f64, polarity));
-        }
-        Ok(events)
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)?;
+        crate::ev_formats::aedat4_reader::read_aedat_4_0(&data, &self.config)
     }
     /// Extract numeric value from a header line
     fn extract_number_from_line(&self, line: &str) -> Option<u16> {
@@ -1197,46 +996,38 @@ mod tests {
         // assert_eq!(metadata.sensor_resolution, Some((346, 240)));
         // Events length is always >= 0 by definition, no need to assert
     }
-    /// Test AEDAT 4.0 format reading
+    /// Test AEDAT 4.0 reading against a real DV-framework sample.
+    ///
+    /// Skips when the sample is unavailable (e.g. CI without the dv-processing
+    /// submodule). The detailed parsing assertions and cross-checked event
+    /// counts live in `aedat4_reader::tests`; this guards the top-level
+    /// `AedatReader::read_file` dispatch path end to end.
     #[test]
     fn test_aedat_4_0_reading() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("test_aedat_4_0.aedat");
-        // Create test AEDAT 4.0 file
-        let mut file = File::create(&file_path).unwrap();
-        // Write header
-        writeln!(file, "AEDAT4").unwrap();
-        writeln!(file, "# sizeX 640").unwrap();
-        writeln!(file, "# sizeY 480").unwrap();
-        // Write test packet header (28 bytes)
-        let packet_type = 1u16; // Polarity events
-        let packet_size = 16u32; // 2 events * 8 bytes each
-        file.write_all(&packet_type.to_le_bytes()).unwrap();
-        file.write_all(&[0u8; 2]).unwrap(); // Reserved
-        file.write_all(&packet_size.to_le_bytes()).unwrap();
-        file.write_all(&[0u8; 20]).unwrap(); // Rest of header
-                                             // Write test events in packet (8 bytes each)
-        let test_events = vec![
-            (1000u32, 100u16, 200u16), // timestamp=1000, x=100, y=200, polarity=1
-            (2000u32, 150u16, 250u16), // timestamp=2000, x=150, y=250, polarity=1
-        ];
-        for (timestamp, x, y) in test_events {
-            file.write_all(&timestamp.to_le_bytes()).unwrap();
-            file.write_all(&x.to_le_bytes()).unwrap();
-            file.write_all(&(y | 0x8000).to_le_bytes()).unwrap(); // Set polarity bit
+        let sample = "lib/dv-processing/tests/io/test_files/sample_data.aedat4";
+        if !std::path::Path::new(sample).exists() {
+            eprintln!("skipping AEDAT 4.0 test: sample {sample} not present");
+            return;
         }
-        // Test reading
-        let reader = AedatReader::new();
-        let (events, metadata) = reader.read_file(&file_path).unwrap();
+        // 346x260 sensor; disable timestamp monotonicity (DV streams interleave
+        // packets but coordinates and polarity are the contract under test).
+        let config = AedatConfig {
+            validate_timestamps: false,
+            validate_coordinates: true,
+            validate_polarity: false,
+            skip_invalid_events: false,
+            max_events: None,
+            max_resolution: Some((346, 260)),
+        };
+        let reader = AedatReader::with_config(config);
+        let (events, metadata) = reader.read_file(sample).unwrap();
         assert_eq!(metadata.version, Some(AedatVersion::V4_0));
-        assert_eq!(metadata.sensor_resolution, Some((640, 480)));
-        assert_eq!(events.height(), 2);
-        // Verify first event
+        assert_eq!(events.height(), 9193);
         let rows = dataframe_to_rows(&events);
-        assert_eq!(rows[0].x, 100);
-        assert_eq!(rows[0].y, 200);
-        assert_eq!(rows[0].polarity, 1); // polarity bit set -> 1
-        assert_eq!(rows[0].t, 1000.0);
+        assert_eq!(rows[0].x, 56);
+        assert_eq!(rows[0].y, 16);
+        assert_eq!(rows[0].polarity, 1); // DV ON event -> -1/1 encoding -> 1
+        assert_eq!(rows[0].t, 1_663_249_605_734_020.0);
     }
     /// Test error handling for invalid files
     #[test]

--- a/src/ev_formats/aer_reader.rs
+++ b/src/ev_formats/aer_reader.rs
@@ -285,9 +285,17 @@ impl AerReader {
             if self.config.generate_timestamps {
                 self.generate_timestamps_for_parsed_events(&mut parsed_events)?;
             }
-            // Add events to builder
+            // Add events to builder.
+            // Generated timestamps are f64 seconds. Converting to microseconds with
+            // a truncating cast would turn e.g. 1.001 s into 1_000_999 us (because
+            // 1.001 * 1e6 is 1000999.999... in f64) instead of the intended
+            // 1_001_000 us. Round the seconds -> microseconds product here
+            // (round-half-up) and feed exact integer microseconds to the builder.
+            // This rounding is AER-local; the shared builder's seconds heuristic is
+            // left untouched for other readers.
             for (x, y, timestamp, polarity) in &parsed_events {
-                builder.add_event(*x, *y, *timestamp, *polarity);
+                let microseconds = (*timestamp * 1_000_000.0).round() as i64;
+                builder.add_event_microseconds(*x, *y, microseconds, *polarity);
             }
             let events = builder.build().map_err(|e| {
                 AerError::Io(std::io::Error::new(
@@ -644,13 +652,14 @@ mod tests {
         let data: Vec<u8> = events_data.into_iter().flatten().collect();
         let (events, _) = reader.parse_events(&data, data.len() as u64).unwrap();
         assert_eq!(events.height(), 3);
-        // Timestamps are stored as Duration(microseconds) via a truncating
+        // Timestamps are stored as Duration(microseconds) via a rounding
         // seconds -> microseconds conversion, so assert on the exact decoded
-        // microsecond integers. Note 1.001 s truncates to 1_000_999 us because
-        // 1.001 * 1e6 is not exactly representable in f64 (1000999.999...).
+        // microsecond integers. Note 1.001 s rounds to 1_001_000 us; a truncating
+        // conversion would instead give 1_000_999 us because 1.001 * 1e6 is not
+        // exactly representable in f64 (1000999.999...).
         let t = events.column("t").unwrap().duration().unwrap();
         assert_eq!(t.get(0).unwrap(), 1_000_000); // start 1.0 s
-        assert_eq!(t.get(1).unwrap(), 1_000_999); // 1.001 s (truncated)
+        assert_eq!(t.get(1).unwrap(), 1_001_000); // 1.001 s (rounded)
         assert_eq!(t.get(2).unwrap(), 1_002_000); // 1.002 s
     }
     #[test]

--- a/src/ev_formats/dataframe_builder.rs
+++ b/src/ev_formats/dataframe_builder.rs
@@ -145,8 +145,8 @@ impl EventDataFrameBuilder {
 
         // VECTORIZED polarity conversion (much faster than per-event)
         let df = match self.format {
-            EventFormat::EVT2 | EventFormat::EVT21 | EventFormat::EVT3 => {
-                // EVT2 family: Convert 0/1 to -1/1 using vectorized operations
+            EventFormat::EVT2 | EventFormat::EVT21 | EventFormat::EVT3 | EventFormat::AEDAT4 => {
+                // EVT2 family and AEDAT 4.0 (DV): Convert 0/1 to -1/1 using vectorized operations
                 df.lazy()
                     .with_column(
                         when(col("polarity").eq(lit(0)))

--- a/src/ev_formats/dataframe_builder.rs
+++ b/src/ev_formats/dataframe_builder.rs
@@ -73,6 +73,21 @@ impl EventDataFrameBuilder {
         self.event_count += 1;
     }
 
+    /// Add a single event with an already-converted microsecond timestamp.
+    ///
+    /// This bypasses the magnitude-based `convert_timestamp` heuristic and stores
+    /// the supplied microsecond value verbatim. It exists for readers (such as AER)
+    /// that compute exact integer-microsecond timestamps themselves and must not be
+    /// re-interpreted as seconds/nanoseconds by the heuristic.
+    pub fn add_event_microseconds(&mut self, x: u16, y: u16, timestamp_us: i64, polarity: bool) {
+        self.x_builder.append_value(x as i16);
+        self.y_builder.append_value(y as i16);
+        self.timestamp_builder.append_value(timestamp_us);
+        self.polarity_builder
+            .append_value(if polarity { 1i8 } else { 0i8 });
+        self.event_count += 1;
+    }
+
     /// Add multiple events in batch
     pub fn add_events_batch(&mut self, events: &[(u16, u16, f64, bool)]) {
         for &(x, y, timestamp, polarity) in events {
@@ -299,6 +314,21 @@ mod tests {
         assert!(column_names.contains(&"y".to_string()));
         assert!(column_names.contains(&"t".to_string()));
         assert!(column_names.contains(&"polarity".to_string()));
+    }
+
+    #[test]
+    fn test_add_event_microseconds_stores_value_verbatim() {
+        let mut builder = EventDataFrameBuilder::new(EventFormat::AER, 4);
+
+        // Values that the magnitude heuristic would misclassify if routed through
+        // convert_timestamp: 1 us (< 1000 => seconds) and 1_001_000 us (>= 1000).
+        builder.add_event_microseconds(10, 20, 1, true);
+        builder.add_event_microseconds(30, 40, 1_001_000, false);
+
+        let df = builder.build().unwrap();
+        let t = df.column("t").unwrap().duration().unwrap();
+        assert_eq!(t.get(0).unwrap(), 1);
+        assert_eq!(t.get(1).unwrap(), 1_001_000);
     }
 
     #[test]

--- a/src/ev_formats/evt3_reader.rs
+++ b/src/ev_formats/evt3_reader.rs
@@ -362,8 +362,18 @@ pub struct Evt3Metadata {
 /// Decoder state for EVT3 events
 #[derive(Debug, Clone, Default)]
 struct DecoderState {
-    /// Current timestamp (24-bit)
-    current_timestamp: u32,
+    /// Full reconstructed timestamp in microseconds (time base including
+    /// TIME_HIGH loops, plus the current 12-bit TIME_LOW).
+    current_timestamp: u64,
+    /// Time base from TIME_HIGH, including accumulated loop offsets, in
+    /// microseconds (always a multiple of 2^12).
+    current_time_base: u64,
+    /// Current 12-bit TIME_LOW value in microseconds.
+    current_time_low: u64,
+    /// Number of TIME_HIGH wraparounds (loops) observed so far.
+    time_high_loop_count: u64,
+    /// Whether the first TIME_HIGH has been seen (initialises the time base).
+    first_time_base_set: bool,
     /// Current Y coordinate
     current_y: u16,
     /// Current polarity
@@ -658,6 +668,10 @@ impl Evt3Reader {
             let mut builder = EventDataFrameBuilder::new(EventFormat::EVT3, estimated_events);
             let mut buffer = vec![0u8; self.config.chunk_size * 2]; // 2 bytes per event
             let mut decoder_state = DecoderState::default();
+            // EVT3 timebase loop constants (12-bit TIME_HIGH << 12, mirrors OpenEB).
+            const MAX_TIMESTAMP_BASE: u64 = ((1u64 << 12) - 1) << 12; // 16_773_120
+            const TIME_LOOP: u64 = MAX_TIMESTAMP_BASE + (1 << 12); // 16_777_216
+            const LOOP_THRESHOLD: u64 = 10 << 12;
             let mut bytes_read_total = 0;
             loop {
                 let bytes_read = file.read(&mut buffer)?;
@@ -679,19 +693,49 @@ impl Evt3Reader {
                             match event_type {
                                 Evt3EventType::TimeLow => {
                                     if let Ok(time_event) = raw_event.as_time_event() {
-                                        // Update lower 12 bits of timestamp
-                                        decoder_state.current_timestamp =
-                                            (decoder_state.current_timestamp & 0xFFF000)
-                                                | time_event.time as u32;
+                                        // Update the lower 12 bits (TIME_LOW) of the timestamp.
+                                        decoder_state.current_time_low = time_event.time as u64;
+                                        decoder_state.current_timestamp = decoder_state
+                                            .current_time_base
+                                            + decoder_state.current_time_low;
                                         decoder_state.has_timestamp = true;
                                     }
                                 }
                                 Evt3EventType::TimeHigh => {
                                     if let Ok(time_event) = raw_event.as_time_event() {
-                                        // Update upper 12 bits of timestamp
-                                        decoder_state.current_timestamp =
-                                            (decoder_state.current_timestamp & 0x000FFF)
-                                                | ((time_event.time as u32) << 12);
+                                        // Update the upper 12 bits (TIME_HIGH) of the timestamp,
+                                        // tracking 24-bit timebase loops so timestamps keep
+                                        // increasing past the ~16.78s wraparound (matches OpenEB).
+                                        let new_time_base = (time_event.time as u64) << 12;
+
+                                        if !decoder_state.first_time_base_set {
+                                            decoder_state.current_time_base = new_time_base;
+                                            decoder_state.first_time_base_set = true;
+                                        } else {
+                                            let candidate_time_base = new_time_base
+                                                + decoder_state.time_high_loop_count * TIME_LOOP;
+
+                                            // Detect a TIME_HIGH wraparound: the new base appears
+                                            // to jump backwards by almost the full 24-bit range.
+                                            let candidate_time_base = if decoder_state
+                                                .current_time_base
+                                                > candidate_time_base
+                                                && decoder_state.current_time_base
+                                                    - candidate_time_base
+                                                    >= MAX_TIMESTAMP_BASE - LOOP_THRESHOLD
+                                            {
+                                                decoder_state.time_high_loop_count += 1;
+                                                candidate_time_base + TIME_LOOP
+                                            } else {
+                                                candidate_time_base
+                                            };
+
+                                            decoder_state.current_time_base = candidate_time_base;
+                                        }
+
+                                        decoder_state.current_timestamp = decoder_state
+                                            .current_time_base
+                                            + decoder_state.current_time_low;
                                         decoder_state.has_timestamp = true;
                                     }
                                 }

--- a/src/ev_formats/format_detector.rs
+++ b/src/ev_formats/format_detector.rs
@@ -134,7 +134,9 @@ impl From<std::io::Error> for FormatDetectionError {
 
 /// Magic bytes for different formats
 const HDF5_MAGIC: &[u8] = b"\x89HDF\r\n\x1a\n";
-const AEDAT4_MAGIC: &[u8] = b"AEDAT4";
+// Real DV-framework AEDAT 4.0 files begin with `#!AER-DAT4.0`. This must be
+// tested before the generic `#!AER-DAT` (3.x) prefix to avoid misdetection.
+const AEDAT4_MAGIC: &[u8] = b"#!AER-DAT4.0";
 const AEDAT3_MAGIC: &[u8] = b"#!AER-DAT";
 const AEDAT2_MAGIC: &[u8] = b"#!AER-DAT2.0";
 const AEDAT1_MAGIC: &[u8] = b"#!AER-DAT1.0";
@@ -194,6 +196,7 @@ impl FormatDetector {
             Some("txt") | Some("dat") => (EventFormat::Text, 0.7),
             Some("h5") | Some("hdf5") => (EventFormat::HDF5, 0.8),
             Some("aer") => (EventFormat::AER, 0.6),
+            Some("aedat4") => (EventFormat::AEDAT4, 0.7), // DV framework, refined by content magic
             Some("aedat") => (EventFormat::AEDAT2, 0.5), // Default to AEDAT2, will be refined by content
             Some("raw") => (EventFormat::EVT2, 0.5), // Default to EVT2, will be refined by content
             Some("bin") => (EventFormat::Binary, 0.6),

--- a/src/ev_formats/format_detector.rs
+++ b/src/ev_formats/format_detector.rs
@@ -477,16 +477,27 @@ impl FormatDetector {
             .properties
             .insert("detection_method".to_string(), "text_analysis".to_string());
 
-        // Analyze first few lines to determine format
+        // Analyze first few lines to determine format. Count only the lines that
+        // carry event data (skip comments and blank lines) so the confidence ratio
+        // is not diluted by header lines.
+        let mut data_line_count = 0;
+
+        // Read up to 10 lines. The buffer must be cleared on every iteration,
+        // including for skipped comment/blank lines, otherwise their contents leak
+        // into the next read and poison the numeric parsing.
         while line_count < 10 && reader.read_line(&mut line)? > 0 {
             line_count += 1;
 
-            if line.trim().is_empty() || line.starts_with('#') {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                line.clear();
                 continue;
             }
 
+            data_line_count += 1;
+
             // Check if line contains space-separated numeric values
-            let parts: Vec<&str> = line.split_whitespace().collect();
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
             if parts.len() >= 4 {
                 let mut valid_parts = 0;
 
@@ -512,8 +523,8 @@ impl FormatDetector {
             line.clear();
         }
 
-        let confidence = if valid_event_lines > 0 {
-            (valid_event_lines as f64 / line_count as f64) * 0.8
+        let confidence = if data_line_count > 0 && valid_event_lines > 0 {
+            (valid_event_lines as f64 / data_line_count as f64) * 0.9
         } else {
             0.3
         };
@@ -527,29 +538,47 @@ impl FormatDetector {
 
     /// Check if content could be AER format
     fn could_be_aer_format(buffer: &[u8], file_size: u64) -> bool {
-        // AER format typically has 18-bit events, often stored as 32-bit values
-        // Check if file size is consistent with 4-byte events
+        // AER format uses an 18-bit event structure (1 bit polarity + 9 bits x +
+        // 9 bits y) stored in 32-bit little-endian words. The address therefore
+        // occupies bits 0..=18; bits 19..=31 are always zero in genuine AER data.
+        // Check if file size is consistent with 4-byte events.
         if !file_size.is_multiple_of(4) {
             return false;
         }
 
-        // Check for patterns typical of AER data
-        // Events should have reasonable coordinate values
-        if buffer.len() >= 8 {
-            let event1 = u32::from_le_bytes([buffer[0], buffer[1], buffer[2], buffer[3]]);
-            let event2 = u32::from_le_bytes([buffer[4], buffer[5], buffer[6], buffer[7]]);
-
-            // Extract x, y coordinates (assuming 9-bit each)
-            let x1 = (event1 >> 1) & 0x1FF;
-            let y1 = (event1 >> 10) & 0x1FF;
-            let x2 = (event2 >> 1) & 0x1FF;
-            let y2 = (event2 >> 10) & 0x1FF;
-
-            // Check if coordinates are reasonable (< 1024 for typical sensors)
-            return x1 < 1024 && y1 < 1024 && x2 < 1024 && y2 < 1024;
+        // Need at least two events to distinguish structured AER data from random
+        // binary. A single 4-byte value is too weak a signal.
+        if buffer.len() < 8 {
+            return false;
         }
 
-        false
+        // Sample every aligned 4-byte event in the buffer and verify the upper bits
+        // (above the 18-bit AER address space) are zero. Random binary data sets
+        // these high bits, so requiring them to be clear rejects false positives
+        // while accepting genuine AER addresses (which never use those bits).
+        const AER_ADDRESS_BITS: u32 = 19; // 1 polarity + 9 x + 9 y
+        let high_bit_mask: u32 = !0u32 << AER_ADDRESS_BITS;
+
+        let mut event_count = 0usize;
+        let mut offset = 0usize;
+        while offset + 4 <= buffer.len() {
+            let event = u32::from_le_bytes([
+                buffer[offset],
+                buffer[offset + 1],
+                buffer[offset + 2],
+                buffer[offset + 3],
+            ]);
+
+            // Any bit set above the AER address space means this is not AER data.
+            if event & high_bit_mask != 0 {
+                return false;
+            }
+
+            event_count += 1;
+            offset += 4;
+        }
+
+        event_count >= 2
     }
 
     /// Analyze AER format

--- a/src/ev_formats/mod.rs
+++ b/src/ev_formats/mod.rs
@@ -22,6 +22,9 @@ pub use format_detector::{
 pub mod aedat_reader;
 pub use aedat_reader::{AedatConfig, AedatError, AedatMetadata, AedatReader, AedatVersion};
 
+// AEDAT 4.0 (DV framework) reader module
+pub mod aedat4_reader;
+
 // AER format reader module
 pub mod aer_reader;
 pub use aer_reader::{AerConfig, AerError, AerMetadata, AerReader, TimestampMode};

--- a/src/ev_formats/prophesee_ecf_codec.rs
+++ b/src/ev_formats/prophesee_ecf_codec.rs
@@ -655,19 +655,16 @@ impl PropheseeECFDecoder {
             for packed_event in vs.iter().take(events_in_group) {
                 let packed_event = *packed_event;
 
-                // Extract fields from packed event (23 bits total per event)
-                // Note: Coordinate values are 11-bit but may need scaling for full sensor range
+                // Extract fields from packed event (23 bits total per event).
+                // The 11-bit x/y fields are the actual sensor coordinates and are
+                // used directly, matching the OpenEB hdf5_ecf reference
+                // (ecf_codec.cpp:199-200), which performs no rescaling.
                 let y_raw = ((packed_event >> 12) & 0x7FF) as u16; // Bits 12-22: Y coordinate (11 bits)
                 let x_raw = ((packed_event >> 1) & 0x7FF) as u16; // Bits 1-11: X coordinate (11 bits)
                 let p = if (packed_event & 1) != 0 { 1 } else { -1 }; // Bit 0: polarity (1 bit)
 
-                // Scale coordinates to full sensor resolution (1280x720)
-                // 11-bit values (0-2047) need to be mapped to sensor dimensions
-                let x = ((x_raw as u32 * 1280) / 2048) as u16; // Scale to 1280 width
-                let y = ((y_raw as u32 * 720) / 2048) as u16; // Scale to 720 height
-
-                x_coords.push(x);
-                y_coords.push(y);
+                x_coords.push(x_raw);
+                y_coords.push(y_raw);
                 polarities.push(p);
 
                 // Event decoded successfully

--- a/src/ev_formats/prophesee_ecf_codec.rs
+++ b/src/ev_formats/prophesee_ecf_codec.rs
@@ -839,26 +839,25 @@ impl PropheseeECFEncoder {
     }
 
     /// Write chunk header
+    ///
+    /// Layout matches the official Prophesee ECF header (and the evlib decoder
+    /// `read_header`): bits 2-31 hold the event count, bit 1 is the
+    /// `ys_xs_and_ps_packed` flag and bit 0 is the `xs_and_ps_packed` flag.
+    /// There is no separate delta-timestamps flag bit; the decoder always
+    /// treats this bit-packed header as delta-timestamp encoded.
     fn write_header(
         &self,
         cursor: &mut Cursor<&mut Vec<u8>>,
         num_events: usize,
         _mode: &EncodingMode,
     ) -> io::Result<()> {
-        // Create bit-packed header matching the new evlib format
-        let mut header = 0u32;
-
-        // Bits 3-31: Number of events (shifted left by 3)
-        header |= (num_events as u32) << 3;
-
-        // Bit 2: delta_timestamps flag - set based on mode
-        // TODO: Use actual mode flag when needed
-        header |= 1u32 << 2; // Always use delta timestamps for now
-
-        // For now, don't set packing flags since we're using uncompressed format
-        // This ensures the header matches the actual data format
-        // Bit 1: ys_xs_and_ps_packed flag = false (not packed)
-        // Bit 0: xs_and_ps_packed flag = false (not packed)
+        // Bits 2-31: number of events.
+        // Bit 1: ys_xs_and_ps_packed flag = false (raw coordinate layout).
+        // Bit 0: xs_and_ps_packed flag = false (raw coordinate layout).
+        // Both packing flags stay clear because `encode_raw_coordinates`
+        // emits the unpacked Y / X / P blocks the decoder reads when neither
+        // flag is set.
+        let header = (num_events as u32) << 2;
 
         cursor.write_u32::<LittleEndian>(header)?;
         Ok(())
@@ -1009,8 +1008,6 @@ impl PropheseeECFEncoder {
 mod tests {
     use super::*;
 
-    #[ignore = "pre-existing ECF codec defect: encode/decode round-trip fails with UnexpectedEof; \
-                unrelated to the API port, tracked separately"]
     #[test]
     fn test_prophesee_ecf_roundtrip() {
         let events = vec![
@@ -1059,8 +1056,6 @@ mod tests {
         }
     }
 
-    #[ignore = "pre-existing ECF codec defect: encode/decode round-trip fails with UnexpectedEof; \
-                unrelated to the API port, tracked separately"]
     #[test]
     fn test_1_bit_delta_encoding() {
         // Test case specifically for 1-bit delta encoding (deltas are 0 or 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,30 +8,10 @@ from pathlib import Path
 import tempfile
 import shutil
 
-# Detect whether the evlib build includes HDF5 support.
-# Mirrors the hdf5_available fixture but available at import time so
-# test modules can apply `pytestmark = requires_hdf5`.
-try:
-    import evlib as _evlib_for_hdf5_probe
-
-    # HDF5 read/write is a cfg-gated Rust feature (--features hdf5). The top-level
-    # evlib.save_events_to_hdf5 is a pure-Python h5py wrapper that always exists, so it
-    # is not a reliable signal. Probe the Rust `formats` submodule, where
-    # save_events_to_hdf5 is only registered when the hdf5 feature is compiled in.
-    _fmt = getattr(_evlib_for_hdf5_probe, "formats", None)
-    HAS_HDF5 = (
-        sys.platform != "win32"
-        and _fmt is not None
-        and hasattr(_fmt, "save_events_to_hdf5")
-    )
-    del _evlib_for_hdf5_probe, _fmt
-except ImportError:
-    HAS_HDF5 = False
-
-requires_hdf5 = pytest.mark.skipif(
-    not HAS_HDF5,
-    reason="HDF5 feature not compiled in (build with --features hdf5)",
-)
+# HDF5 support detection lives in a dedicated helper module so it can be
+# imported via the package-qualified path from test modules. Re-exported here
+# for backwards compatibility with any code that still reads them off conftest.
+from tests.hdf5_support import HAS_HDF5, requires_hdf5  # noqa: F401
 
 # Add the project root to the Python path
 project_root = Path(__file__).parent.parent

--- a/tests/hdf5_support.py
+++ b/tests/hdf5_support.py
@@ -1,0 +1,38 @@
+"""
+HDF5 support detection helpers for the evlib test suite.
+
+Kept in a dedicated module (rather than ``tests/conftest.py``) so that test
+files can import ``HAS_HDF5`` / ``requires_hdf5`` via the package-qualified path
+``from tests.hdf5_support import ...``. A bare ``from conftest import ...`` is
+fragile because ``conftest`` can resolve to the wrong conftest when bare
+``pytest`` collects multiple directories.
+"""
+
+import sys
+
+import pytest
+
+# Detect whether the evlib build includes HDF5 support.
+# Mirrors the hdf5_available fixture but available at import time so
+# test modules can apply `pytestmark = requires_hdf5`.
+try:
+    import evlib as _evlib_for_hdf5_probe
+
+    # HDF5 read/write is a cfg-gated Rust feature (--features hdf5). The top-level
+    # evlib.save_events_to_hdf5 is a pure-Python h5py wrapper that always exists, so it
+    # is not a reliable signal. Probe the Rust `formats` submodule, where
+    # save_events_to_hdf5 is only registered when the hdf5 feature is compiled in.
+    _fmt = getattr(_evlib_for_hdf5_probe, "formats", None)
+    HAS_HDF5 = (
+        sys.platform != "win32"
+        and _fmt is not None
+        and hasattr(_fmt, "save_events_to_hdf5")
+    )
+    del _evlib_for_hdf5_probe, _fmt
+except ImportError:
+    HAS_HDF5 = False
+
+requires_hdf5 = pytest.mark.skipif(
+    not HAS_HDF5,
+    reason="HDF5 feature not compiled in (build with --features hdf5)",
+)

--- a/tests/test_aedat4_dv_reader.py
+++ b/tests/test_aedat4_dv_reader.py
@@ -1,0 +1,64 @@
+"""End-to-end tests for the AEDAT 4.0 (iniVation DV framework) reader.
+
+These exercise ``evlib.load_events`` / ``evlib.detect_format`` against the real
+``.aedat4`` sample files shipped under the ``dv-processing`` reference checkout.
+The expected event counts and first-event values were cross-checked against
+``dv-processing`` 2.0.3 (``dv_processing.io.MonoCameraRecording``).
+
+Each test skips when its sample file is absent so the suite still passes in CI
+environments that do not vendor the dv-processing submodule.
+"""
+
+import os
+
+import pytest
+
+import evlib
+
+# (relative path, expected event count, x bounds, y bounds, expected polarity set)
+SAMPLES = [
+    (
+        "lib/dv-processing/tests/io/test_files/sample_data.aedat4",
+        9193,
+        (0, 345),
+        (0, 259),
+        {1},  # reference: all 9193 events are ON in this stream
+    ),
+    (
+        "lib/dv-processing/python/tests/data/sample_data.aedat4",
+        9408,
+        (63, 512),
+        (47, 384),
+        {1},
+    ),
+    (
+        "lib/dv-processing/tests/io/test_files/test-minimal.aedat4",
+        255283,
+        (0, 639),
+        (0, 479),
+        {-1, 1},
+    ),
+]
+
+
+@pytest.mark.parametrize("path,count,xb,yb,pols", SAMPLES)
+def test_aedat4_load(path, count, xb, yb, pols):
+    if not os.path.exists(path):
+        pytest.skip(f"sample file not present: {path}")
+
+    detected = evlib.detect_format(path)
+    # detect_format returns (name, confidence, metadata)
+    assert detected[0] == "AEDAT 4.0"
+
+    df = evlib.load_events(path).collect()
+
+    assert len(df) == count
+    assert df["x"].min() >= xb[0]
+    assert df["x"].max() <= xb[1]
+    assert df["y"].min() >= yb[0]
+    assert df["y"].max() <= yb[1]
+    assert set(df["polarity"].unique().to_list()) == pols
+
+    # Timestamps are stored as Duration(us); DV timestamps are positive.
+    t_us = df["t"].dt.total_microseconds()
+    assert t_us.min() > 0

--- a/tests/test_aedat_address_decoding.rs
+++ b/tests/test_aedat_address_decoding.rs
@@ -382,9 +382,6 @@ fn test_aedat_4_0_address_decoding() {
 }
 
 /// Test coordinate bounds checking
-#[ignore = "pre-existing AEDAT reader defect: max_resolution bounds are not enforced so \
-            read_file does not return an error for out-of-bounds coordinates; unrelated to the \
-            API port, tracked separately"]
 #[test]
 fn test_coordinate_bounds_checking() {
     let temp_dir = TempDir::new().unwrap();

--- a/tests/test_aedat_address_decoding.rs
+++ b/tests/test_aedat_address_decoding.rs
@@ -308,76 +308,48 @@ fn test_aedat_3_1_validity_bit() {
     assert_eq!(events[1].y, 60);
 }
 
-/// Test AEDAT 4.0 address decoding with DV framework format
+/// Test AEDAT 4.0 reading against a real DV-framework sample file.
+///
+/// The legacy "28-byte packet header" layout that previous revisions invented
+/// does not exist in the DV framework, so there is no synthetic event to decode
+/// here. Instead this validates the real reader against a genuine `.aedat4`
+/// recording, with the expected event count and first event cross-checked
+/// against dv-processing 2.0.3. Skips when the sample is absent.
 #[test]
 fn test_aedat_4_0_address_decoding() {
-    let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("test_aedat_4_0_address.aedat");
-
-    // Create test AEDAT 4.0 file
-    let mut file = File::create(&file_path).unwrap();
-    writeln!(file, "AEDAT4").unwrap();
-    writeln!(file, "# sizeX 640").unwrap();
-    writeln!(file, "# sizeY 480").unwrap();
-
-    // Write test packet header (28 bytes)
-    let packet_type = 1u16; // Polarity events
-    let packet_size = 32u32; // 4 events * 8 bytes each
-
-    file.write_all(&packet_type.to_le_bytes()).unwrap();
-    file.write_all(&[0u8; 2]).unwrap(); // Reserved
-    file.write_all(&packet_size.to_le_bytes()).unwrap();
-    file.write_all(&[0u8; 20]).unwrap(); // Rest of header
-
-    // Test various coordinate combinations
-    // AEDAT 4.0 format: timestamp (32-bit) + x (16-bit) + y (16-bit with MSB as polarity)
-    let test_cases = vec![
-        // (expected_x, expected_y, expected_polarity, timestamp)
-        (0, 0, 1, 1000),
-        (0, 0, -1, 2000),
-        (100, 200, 1, 3000),
-        (639, 479, -1, 4000), // Max resolution
-    ];
-
-    for (x, y, polarity, timestamp) in &test_cases {
-        // Create event according to AEDAT 4.0 specification
-        let y_with_polarity = (*y as u16) | if *polarity > 0 { 0x8000 } else { 0 };
-
-        file.write_all(&(*timestamp as u32).to_le_bytes()).unwrap();
-        file.write_all(&(*x as u16).to_le_bytes()).unwrap();
-        file.write_all(&y_with_polarity.to_le_bytes()).unwrap();
+    let sample = "lib/dv-processing/tests/io/test_files/sample_data.aedat4";
+    if !std::path::Path::new(sample).exists() {
+        eprintln!("skipping AEDAT 4.0 decoding test: {sample} not present");
+        return;
     }
 
-    // Test reading
-    let reader = AedatReader::new();
-    let (df, metadata) = reader.read_file(&file_path).unwrap();
+    // 346x260 sensor. DV polarity ON -> 1, OFF -> -1 after conversion.
+    let config = AedatConfig {
+        validate_timestamps: false,
+        validate_coordinates: true,
+        validate_polarity: false,
+        skip_invalid_events: false,
+        max_events: None,
+        max_resolution: Some((346, 260)),
+    };
+    let reader = AedatReader::with_config(config);
+    let (df, metadata) = reader.read_file(sample).unwrap();
     let events = dataframe_to_rows(&df);
 
     assert_eq!(metadata.version, Some(AedatVersion::V4_0));
-    assert_eq!(events.len(), test_cases.len());
+    assert_eq!(events.len(), 9193);
 
-    // Verify each event (AEDAT encodes polarity as ON -> 1, OFF -> 0)
-    for (i, (expected_x, expected_y, expected_polarity, expected_timestamp)) in
-        test_cases.iter().enumerate()
-    {
-        let event = &events[i];
-        assert_eq!(
-            event.x, *expected_x as u16,
-            "Event {i}: X coordinate mismatch"
-        );
-        assert_eq!(
-            event.y, *expected_y as u16,
-            "Event {i}: Y coordinate mismatch"
-        );
-        assert_eq!(
-            event.polarity,
-            if *expected_polarity > 0 { 1 } else { 0 },
-            "Event {i}: Polarity mismatch"
-        );
-        assert_eq!(
-            event.t, *expected_timestamp as i64,
-            "Event {i}: Timestamp mismatch"
-        );
+    // First event cross-checked against dv-processing.
+    assert_eq!(events[0].x, 56);
+    assert_eq!(events[0].y, 16);
+    assert_eq!(events[0].polarity, 1); // ON event
+    assert_eq!(events[0].t, 1_663_249_605_734_020);
+
+    // Coordinates within sensor bounds; polarity strictly in {-1, 1}.
+    for event in &events {
+        assert!(event.x < 346);
+        assert!(event.y < 260);
+        assert!(event.polarity == 1 || event.polarity == -1);
     }
 }
 

--- a/tests/test_build_profile.py
+++ b/tests/test_build_profile.py
@@ -10,7 +10,7 @@ import sys
 import pytest
 
 import evlib
-from conftest import HAS_HDF5
+from tests.hdf5_support import HAS_HDF5
 
 
 def test_has_hdf5_is_bool():

--- a/tests/test_clean_loading.py
+++ b/tests/test_clean_loading.py
@@ -9,7 +9,7 @@ import evlib
 import os
 import sys
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 pytestmark = requires_hdf5
 

--- a/tests/test_clean_output.py
+++ b/tests/test_clean_output.py
@@ -7,7 +7,7 @@ import evlib
 import io
 from contextlib import redirect_stderr
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 pytestmark = requires_hdf5
 

--- a/tests/test_ev_filtering_pandera.py
+++ b/tests/test_ev_filtering_pandera.py
@@ -27,7 +27,7 @@ from typing import Optional, Union
 import polars as pl
 import pytest
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 # Skip entire module on Windows - uses HDF5 files, and skip when HDF5
 # feature is not compiled into the current build.

--- a/tests/test_evlib_regression.py
+++ b/tests/test_evlib_regression.py
@@ -23,7 +23,7 @@ import pytest
 # Add the project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 import evlib
 

--- a/tests/test_evt3_formats.rs
+++ b/tests/test_evt3_formats.rs
@@ -438,6 +438,86 @@ mod evt3_tests {
         assert!(df_no_validation.height() > 0);
     }
 
+    /// Regression test for the EVT3 timestamp loop/wraparound bug.
+    ///
+    /// EVT3's timebase is 24 bits at 1us resolution (12-bit TIME_HIGH << 12 |
+    /// 12-bit TIME_LOW), so it wraps every 2^24 us ~= 16.78s. OpenEB's reference
+    /// decoder tracks the number of TIME_HIGH loops and adds `loop_count *
+    /// TimeLoop` so timestamps keep increasing past the wrap. evlib must do the
+    /// same (it already does for EVT2 and EVT2.1). Before the fix, the second
+    /// event below decoded at t=0.0s instead of ~16.777216s, i.e. the stream went
+    /// backwards in time.
+    #[test]
+    fn test_evt3_timestamp_wraparound_is_monotonic() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test_evt3_wraparound.raw");
+
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "% evt 3.0").unwrap();
+        writeln!(file, "% format EVT3;height=480;width=640").unwrap();
+        writeln!(file, "% geometry 640x480").unwrap();
+        writeln!(file, "% end").unwrap();
+
+        let mut binary_data = Vec::new();
+        let mut push = |word: u16| binary_data.extend_from_slice(&word.to_le_bytes());
+
+        // --- Event A, just below the 24-bit timebase ceiling ---
+        // TIME_HIGH = 0xFFF -> time_base = 0xFFF << 12 = 0xFFF000 = 16_773_120 us
+        push((0x8u16 << 12) | 0xFFF);
+        // TIME_LOW = 0x000
+        push(0x6u16 << 12);
+        // Y = 100
+        push(evt3_word(0x0, 100));
+        // X = 100, positive polarity -> emits event A at t = 16_773_120 us
+        push((0x2u16 << 12) | (1u16 << 11) | 100);
+
+        // --- Event B, after the TIME_HIGH wraps back to 0x000 ---
+        // TIME_HIGH = 0x000 -> with loop handling time_base = 0x1000000 = 16_777_216 us
+        push(0x8u16 << 12);
+        // TIME_LOW = 0x000
+        push(0x6u16 << 12);
+        // Y = 100
+        push(evt3_word(0x0, 100));
+        // X = 100, positive polarity -> emits event B at t = 16_777_216 us
+        push((0x2u16 << 12) | (1u16 << 11) | 100);
+
+        file.write_all(&binary_data).unwrap();
+
+        let config = Evt3Config {
+            validate_coordinates: false,
+            skip_invalid_events: false,
+            max_events: Some(100),
+            sensor_resolution: Some((640, 480)),
+            chunk_size: 1000,
+            polarity_encoding: None,
+        };
+        let reader = Evt3Reader::with_config(config);
+        let (df, _) = reader.read_file(&file_path).unwrap();
+        let events = dataframe_to_rows(&df);
+
+        assert_eq!(events.len(), 2, "expected exactly two CD events");
+
+        // Event A: 16_773_120 us = 16.773120 s
+        assert!(
+            (events[0].t - 16.773_120).abs() < 1e-9,
+            "event A timestamp wrong: {}",
+            events[0].t
+        );
+        // Event B must NOT wrap back to 0; OpenEB decodes it at 16_777_216 us.
+        assert!(
+            (events[1].t - 16.777_216).abs() < 1e-9,
+            "event B timestamp wrapped instead of accumulating the time-high loop: {}",
+            events[1].t
+        );
+        // The decoded stream must be monotonic across the TIME_HIGH wrap.
+        assert!(
+            events[1].t > events[0].t,
+            "timestamps went backwards across the wrap: {} -> {}",
+            events[0].t,
+            events[1].t
+        );
+    }
+
     #[test]
     fn test_evt3_config_defaults() {
         let config = Evt3Config::default();

--- a/tests/test_filtering_real_data.py
+++ b/tests/test_filtering_real_data.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 # Skip entire module on Windows - uses HDF5 files
 pytestmark = pytest.mark.skipif(

--- a/tests/test_format_detection.rs
+++ b/tests/test_format_detection.rs
@@ -63,9 +63,6 @@ fn create_random_binary_file() -> NamedTempFile {
     temp_file
 }
 
-#[ignore = "pre-existing format-detector behaviour: synthetic text scores only 0.30 confidence, \
-            below the 0.7 assertion; detector heuristics differ from the test's thresholds, \
-            unrelated to the API port, tracked separately"]
 #[test]
 fn test_text_format_detection() {
     // Test real text files
@@ -179,9 +176,6 @@ fn test_aer_format_detection() {
     );
 }
 
-#[ignore = "pre-existing format-detector behaviour: random binary data is classified as AER \
-            rather than Unknown/Binary because the AER detector accepts any 4-byte-aligned data; \
-            unrelated to the API port, tracked separately"]
 #[test]
 fn test_unknown_format_detection() {
     let random_file = create_random_binary_file();

--- a/tests/test_hdf5_save_cross_platform.py
+++ b/tests/test_hdf5_save_cross_platform.py
@@ -11,7 +11,7 @@ import os
 import numpy as np
 import pytest
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 pytestmark = requires_hdf5
 

--- a/tests/test_load_events_validation.py
+++ b/tests/test_load_events_validation.py
@@ -30,7 +30,7 @@ from typing import Dict, Any
 import polars as pl
 import pytest
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 # Import validation helpers from tests directory
 try:

--- a/tests/test_prophesee_ecf_fix.py
+++ b/tests/test_prophesee_ecf_fix.py
@@ -8,7 +8,7 @@ import os
 import pytest
 from pathlib import Path
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 # h5py is not available on Windows (HDF5 is Unix-only)
 h5py = pytest.importorskip("h5py", reason="h5py not available on Windows")

--- a/tests/test_prophesee_ecf_integration.rs
+++ b/tests/test_prophesee_ecf_integration.rs
@@ -68,10 +68,6 @@ fn test_prophesee_file_exists() {
     );
 }
 
-#[ignore = "pre-existing detector representation change: file size is exposed as the typed \
-            metadata.file_size field, not as a \"file_size\" key in the properties map, so this \
-            properties.contains_key assertion no longer holds; unrelated to the API port, tracked \
-            separately"]
 #[test]
 fn test_prophesee_format_detection() {
     if is_running_in_ci() || !Path::new(PROPHESEE_TEST_FILE).exists() {
@@ -94,11 +90,8 @@ fn test_prophesee_format_detection() {
         detection_result.confidence
     );
 
-    // Check metadata
-    assert!(detection_result
-        .metadata
-        .properties
-        .contains_key("file_size"));
+    // Check metadata: file size is exposed as a typed field on the metadata struct.
+    assert!(detection_result.metadata.file_size > 0);
     println!(
         "✓ Format detection: {:?} (confidence: {:.2})",
         detection_result.format, detection_result.confidence

--- a/tests/test_prophesee_ecf_integration.rs
+++ b/tests/test_prophesee_ecf_integration.rs
@@ -42,6 +42,65 @@ fn dataframe_to_rows(df: &polars::prelude::DataFrame) -> Vec<EventRow> {
         .collect()
 }
 
+/// Regression test for the ECF packed-coordinate scaling bug.
+///
+/// In the `ys_xs_and_ps_packed` path, each event packs an 11-bit y (bits 12-22),
+/// an 11-bit x (bits 1-11), and a polarity (bit 0) into a 24-bit slot. The OpenEB
+/// reference (lib/hdf5_ecf/ecf_codec.cpp:199-200) uses those 11-bit fields as the
+/// actual sensor coordinates. evlib instead rescaled them (`x*1280/2048`,
+/// `y*720/2048`), silently corrupting every packed event. This builds a packed
+/// chunk by hand and asserts the decoded coordinates equal the raw 11-bit values.
+/// Pure-Rust codec path, so it runs without the `hdf5` feature.
+#[test]
+fn test_prophesee_ecf_packed_coordinates_are_not_rescaled() {
+    use evlib::ev_formats::PropheseeECFDecoder;
+
+    // (x, y, polarity_bit) chosen so the buggy rescaling would change them:
+    //   x=1024 -> 1024*1280/2048 = 640 ; y=512 -> 512*720/2048 = 180
+    let events = [
+        (1024u16, 512u16, 1u32),
+        (2000, 700, 0),
+        (100, 200, 1),
+        (2047, 2047, 0),
+    ];
+
+    // Pack each event into its 24-bit slot: (y << 12) | (x << 1) | polarity.
+    let vs: Vec<u32> = events
+        .iter()
+        .map(|&(x, y, p)| ((y as u32) << 12) | ((x as u32) << 1) | p)
+        .collect();
+
+    // Re-interleave the four 24-bit slots into three 32-bit words, the exact
+    // inverse of the decoder's unpacking.
+    let word0 = (vs[0] << 8) | (vs[1] & 0xFF);
+    let word1 = ((vs[1] >> 8) << 16) | (vs[2] & 0xFFFF);
+    let word2 = ((vs[2] >> 16) << 24) | vs[3];
+
+    let mut chunk = Vec::new();
+    // Header: bits 2-31 = event count, bit 1 = ys_xs_and_ps_packed.
+    chunk.extend_from_slice(&(((events.len() as u32) << 2) | 0x2).to_le_bytes());
+    // Base timestamp (i64).
+    chunk.extend_from_slice(&1_000i64.to_le_bytes());
+    // Packed coordinate words.
+    chunk.extend_from_slice(&word0.to_le_bytes());
+    chunk.extend_from_slice(&word1.to_le_bytes());
+    chunk.extend_from_slice(&word2.to_le_bytes());
+    // Timestamp section: delta_bits = 0 -> every timestamp equals the base.
+    chunk.push(0u8);
+
+    let decoder = PropheseeECFDecoder::new();
+    let decoded = decoder.decode(&chunk).expect("packed chunk should decode");
+
+    assert_eq!(decoded.len(), events.len());
+    for (i, &(x, y, p)) in events.iter().enumerate() {
+        assert_eq!(decoded[i].x, x, "event {i}: x must not be rescaled");
+        assert_eq!(decoded[i].y, y, "event {i}: y must not be rescaled");
+        let expected_p = if p == 1 { 1 } else { -1 };
+        assert_eq!(decoded[i].p, expected_p, "event {i}: polarity");
+        assert_eq!(decoded[i].t, 1_000, "event {i}: timestamp");
+    }
+}
+
 /// Check if we're running in CI environment
 fn is_running_in_ci() -> bool {
     env::var("CI").is_ok()

--- a/tests/test_prophesee_real_data.py
+++ b/tests/test_prophesee_real_data.py
@@ -7,7 +7,7 @@ import sys
 import traceback
 from pathlib import Path
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 
 @requires_hdf5

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -7,7 +7,7 @@ import evlib.representations as evr
 import tempfile
 import os
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 pytestmark = requires_hdf5
 

--- a/tests/test_rvt_regression.py
+++ b/tests/test_rvt_regression.py
@@ -11,7 +11,7 @@ import numpy as np
 import polars as pl
 import pytest
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 import evlib.representations as evr
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,7 +9,7 @@ import sys
 import pytest
 from pathlib import Path
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 
 def find_test_data() -> Path:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,7 +9,7 @@ import numpy as np
 from pathlib import Path
 import logging
 
-from conftest import requires_hdf5
+from tests.hdf5_support import requires_hdf5
 
 pytestmark = requires_hdf5
 


### PR DESCRIPTION
Fixes five pre-existing parser/codec defects surfaced (and `#[ignore]`-tracked) when the Rust tests were ported in the thin-core refactor, and adds a real iniVation DV-framework AEDAT 4.0 reader (previously `.aedat4` files were misdetected and unreadable). Each change follows TDD against the real sample data; no fabricated implementations.

## Bug fixes

- **AEDAT coordinate bounds** (`aedat_reader.rs`): `max_resolution` was never enforced (the 1.0 path gated on the wrong config field and compared against a hardcoded `127`; other paths had no check). Now enforced across all decode paths, returning `CoordinateOutOfBounds` (or skipping when `skip_invalid_events`), matching the EVT readers.
- **Format-detector text confidence** (`format_detector.rs`): a missing `line.clear()` on the comment/blank branch starved the parser, collapsing confidence to the 0.3 fallback. Fixed; genuine text now scores ~0.9.
- **Format-detector AER false positive** (`format_detector.rs`): AER accepted any 4-byte-aligned data. Now uses a precise structural signal (genuine AER addresses are 18-bit in a 32-bit word, so bits 19-31 must be zero), so random binary is rejected.
- **Prophesee ECF encoder round-trip** (`prophesee_ecf_codec.rs`): the test-only encoder wrote the chunk header as `count<<3|flag` while the decoder and OpenEB use `count<<2`, so 3 events decoded as 7 and hit `UnexpectedEof`. Encoder-only fix; the production decoder (which reads real Prophesee HDF5) is untouched.
- **AER timestamp rounding** (`aer_reader.rs`): generated f64-second timestamps were truncated to microseconds (`1.001 s -> 1_000_999 us`). Now rounded (`-> 1_001_000 us`) via an additive, AER-local builder method that does not change the shared timestamp path used by other readers.
- **EVT3 timestamp wraparound** (`evt3_reader.rs`): the EVT3 reader had no 24-bit timebase loop handling, so timestamps wrapped to zero every ~16.78s (`2^24` us) and went backwards: this corrupts every EVT3 recording longer than ~17s, including the minutes-long Gen4/eTram automotive sequences. EVT2 and EVT2.1 already implemented this; EVT3 now tracks a `u64` time base plus a TIME_HIGH loop counter with the EVT3-specific constants, matching the OpenEB standalone decoder. Verified against `lib/openeb/.../metavision_evt3_raw_file_decoder.cpp`.
- **ECF packed-coordinate rescaling** (`prophesee_ecf_codec.rs`): the `ys_xs_and_ps_packed` decode path (the default for real Prophesee HDF5) extracted the 11-bit x/y correctly then wrongly rescaled them (`x*1280/2048`, `y*720/2048`), silently corrupting every packed event. The OpenEB/hdf5_ecf reference (`lib/hdf5_ecf/ecf_codec.cpp:199-200`) uses the 11-bit fields as the sensor coordinates with no scaling; the scaling is removed.
- **Detector test** (`test_prophesee_ecf_integration.rs`): updated a stale assertion to read the typed `metadata.file_size` field.

## Feature: real AEDAT 4.0 (DV framework) reader

`.aedat4` files were misdetected as AEDAT 3.1 (the magic check looked for `AEDAT4` instead of `#!AER-DAT4.0`) and the 4.0 path used an invented 28-byte-header parser that does not exist in DV. Replaced with a real reader (`aedat4_reader.rs`): parses the version line, the size-prefixed `IOHeader` FlatBuffer (compression, `dataTablePosition`, XML info node), the packet stream, LZ4 decompression (`lz4_flex`), and the `EventPacket` FlatBuffer, selecting the events stream and emitting `x:Int16, y:Int16, t:Duration(us), polarity:Int8(-1/1)`. Detection fixed in both `aedat_reader.rs` and `format_detector.rs`. FlatBuffer parsing is hand-written against the in-repo DV `.fbs` schemas (no codegen/runtime coupling); LZ4 (incl. LZ4_HIGH) is supported.

Cross-checked against `dv-processing` 2.0.3 (exact matches): `sample_data.aedat4` 9193 events, `python/tests/.../sample_data.aedat4` 9408, `test-minimal.aedat4` 255283 (first event, coordinates, polarity, and bounds all verified).

## Verification

- All documenting tests un-ignored and passing; full Rust suite green (`cargo test --features python`, libpython linked), `cargo clippy --all-targets --features python -- -D warnings` clean, `cargo fmt --check` clean.
- The EVT3 wraparound and ECF rescaling fixes were each written test-first: `test_evt3_timestamp_wraparound_is_monotonic` (synthetic stream crossing the 24-bit TIME_HIGH boundary; asserts monotonic 16.773120s -> 16.777216s) and `test_prophesee_ecf_packed_coordinates_are_not_rescaled` (hand-built packed chunk; asserts raw 11-bit coords). Both failed before the fix and pass after.
- EVT3 fix re-verified from Python after `maturin develop`: `tests/test_evt3_comprehensive.py` (real EVT3 sample) and the ECF codec test pass.
- Python suite: 70 passed, 56 skipped, 0 failed (3 new AEDAT 4.0 tests, guarded to skip when the sample is absent).
- Real-sample no-regression: EVT2 `80_balls.raw` -> EVT2 @0.95 (620,596), `slider_depth` -> Text @0.90 (1,078,541), `sample_data.aedat4` -> AEDAT 4.0 (9,193).

## Scope notes

- Two ECF changes are independent: the earlier encoder round-trip fix (chunk-header packing) and the new packed-coordinate rescaling fix in the decoder. The decoder change is validated by a pure-Rust unit test against a hand-built packed chunk and cross-checked against the OpenEB/hdf5_ecf reference; the full HDF5-to-ECF integration still could not be re-run locally (the hdf5 feature does not build against the local Homebrew HDF5, and the real sample is gitignored).
- AEDAT 4.0: Zstd-compressed packets are not supported (no sample uses them) and return a clear error rather than a fake decode; the file is read into memory (fine for these multi-MB samples).
- One Rust test remains `#[ignore]`d: it needs a configured embedded Python interpreter unavailable to a native cargo-test binary (covered by the pytest suite).
- New dependency: `lz4_flex` (LZ4 decompression for AEDAT 4.0).
