### PR TITLE
feat(data): evlib.data training-readiness (phase 2) - augmentation, label preprocessing, N-Caltech101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -735,6 +735,7 @@ data/gen1_processed_RVT
 data/gen4_1mpx_original
 data/gen4_1mpx_processed_EVLIB
 data/gen4_1mpx_processed_RVT
+data/gen4_label_preprocess
 
 data/slider_depth
 

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -183,6 +183,41 @@ to reset state at slot boundaries.
 Map-style dataset for the single-sample (non-sequential) classification path: each
 item is one window with its label, rather than a sequence.
 
+#### Classification: N-Caltech101
+
+`SampleDataset` drives the classification path end to end with the N-Caltech101
+helpers in `evlib.data.ncaltech`. N-Caltech101 recordings are ATIS binary event
+streams (`.bin`, 5 bytes per event, sensor 240 wide by 180 high). Each recording
+becomes a single classification sample: one full-recording stacked-histogram
+window of shape `[2 * nbins, 180, 240]` (`uint8`, polarity-major channels, default
+`nbins=10` gives 20 channels).
+
+`convert_ncaltech(raw_tree, out_dir)` walks `raw_tree/<class_name>/*.bin`, builds
+the class-to-int label map as `sorted(class_dir_names)` mapped to `0..K-1`, writes
+one `<idx>.npy` per recording plus a parallel `labels.npy`, and returns the
+per-sample paths and integer labels ready to hand straight to `SampleDataset`.
+
+```python
+from torch.utils.data import DataLoader
+from evlib.data import convert_ncaltech, SampleDataset
+
+# raw_tree/airplane/*.bin, raw_tree/camera/*.bin, ...
+sample_paths, labels = convert_ncaltech("raw_tree", "out_dir", nbins=10)
+
+dataset = SampleDataset(sample_paths, labels)
+loader = DataLoader(dataset, batch_size=2, shuffle=True)
+
+inputs, targets = next(iter(loader))
+print(tuple(inputs.shape))  # [B, 2 * nbins, 180, 240], e.g. (2, 20, 180, 240)
+```
+
+The full N-Caltech101 dataset is not bundled with evlib; download it separately and
+point `convert_ncaltech` at the extracted class tree. The lower-level
+`read_atis_bin` (decode one `.bin` to a Polars event frame) and
+`representation_from_events` (build one recording's stacked histogram) are exported
+from `evlib.data` for custom pipelines, along with `NCALTECH_HEIGHT` (180) and
+`NCALTECH_WIDTH` (240).
+
 ## Collate functions
 
 `custom_collate_random` stacks a list of `SequenceSample`s into a batch dict keyed by

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -213,15 +213,17 @@ by `PreprocessedH5Source` and `EvlibStreamSource`. Output is byte-identical to R
 ```python
 BBOX_DTYPE   # numpy structured dtype: (t, x, y, w, h, class_id, class_confidence, track_id)
 LABEL_NPZ_FIELDS  # tuple of field names drawn from BBOX_DTYPE
-RVT_REPR_DIR_NAME = "stacked_histogram_dt=50_nbins=10"  # on-disk repr directory name (RVT form)
+EVLIB_REPR_DIR_NAME = "stacked_histogram_dt50_nbins10"  # evlib-native form (no = signs)
+RVT_REPR_DIR_NAME = "stacked_histogram_dt=50_nbins=10"  # RVT upstream form (with = signs)
 
 class NoLabelsError(Exception): ...       # raised when all boxes are removed by filters
 ```
 
-Note: `RVT_REPR_DIR_NAME` uses `=` separators to match RVT's on-disk layout. The
-`PreprocessedH5Source` default `repr_name` uses the no-`=` form
-`"stacked_histogram_dt50_nbins10"`; pass `repr_dir_name=RVT_REPR_DIR_NAME` when writing
-with `preprocess_sequence` and the corresponding value when constructing the source.
+`preprocess_sequence` and `write_preprocessed` default to `EVLIB_REPR_DIR_NAME` (no `=`
+signs), which is the form read by the default `PreprocessedH5Source` and
+`EvlibStreamSource`. Pass `repr_dir_name=RVT_REPR_DIR_NAME` only when reproducing RVT's
+upstream on-disk layout exactly (e.g. to verify byte-identity against a reference tree
+produced by `lib/RVT/scripts/genx/preprocess_dataset.py`).
 
 ### Core functions
 
@@ -266,7 +268,7 @@ def write_preprocessed(
     out_dir: Union[str, Path],
     result: ObjframeGridResult,
     *,
-    repr_dir_name: str = RVT_REPR_DIR_NAME,
+    repr_dir_name: str = EVLIB_REPR_DIR_NAME,
 ) -> None:
     """Write the RVT directory tree for one sequence.
 
@@ -283,7 +285,7 @@ def preprocess_sequence(
     split: str = "val",
     height: int = 720,
     width: int = 1280,
-    repr_dir_name: str = RVT_REPR_DIR_NAME,
+    repr_dir_name: str = EVLIB_REPR_DIR_NAME,
 ) -> ObjframeGridResult:
     """End-to-end pipeline: read -> filter -> grid -> write.
 
@@ -295,8 +297,9 @@ def preprocess_sequence(
 ### Typical usage
 
 ```python
-from evlib.data import preprocess_sequence, RVT_REPR_DIR_NAME, PreprocessedH5Source
+from evlib.data import preprocess_sequence, EVLIB_REPR_DIR_NAME, PreprocessedH5Source
 
+# Default repr_dir_name=EVLIB_REPR_DIR_NAME pairs with the default PreprocessedH5Source.
 result = preprocess_sequence(
     "data/gen4/train/seq0/seq0_bbox.npy",
     out_dir="data/gen4/train/seq0/",
@@ -306,10 +309,17 @@ result = preprocess_sequence(
     width=1280,
 )
 
-# The processed sequence is now readable by PreprocessedH5Source:
-source = PreprocessedH5Source(
-    "data/gen4/train/seq0/",
-    repr_name=RVT_REPR_DIR_NAME,
+# The processed sequence is readable by PreprocessedH5Source with no extra config:
+source = PreprocessedH5Source("data/gen4/train/seq0/")
+
+# To reproduce RVT's upstream on-disk layout (= signs in dir name), pass explicitly:
+from evlib.data import RVT_REPR_DIR_NAME
+result = preprocess_sequence(
+    "data/gen4/train/seq0/seq0_bbox.npy",
+    out_dir="data/gen4/train/seq0/",
+    dataset="gen4",
+    split="train",
+    repr_dir_name=RVT_REPR_DIR_NAME,
 )
 ```
 

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -169,8 +169,11 @@ sequence is zero-padded (tracked via `is_padded_mask`). Shuffle freely with a
 `DataLoader`, since items carry no cross-item state.
 
 ```python
-def SequenceRandomDataset(sources, sequence_length)
+def SequenceRandomDataset(sources, sequence_length, augmentor=None)
 ```
+
+Pass an optional `augmentor` (see the Augmentation section) to transform each
+sequence; fresh augmentation parameters are drawn per item.
 
 ### `SequenceStreamDataset`
 

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -75,8 +75,87 @@ def EvlibStreamSource(
 )
 ```
 
+**Training-ready memoisation.** `EvlibStreamSource` is now suitable for use inside a
+`DataLoader` training loop. The first call to `read_windows` in each worker runs
+`_ensure_time`, which reads the full raw uint32 time column once, corrects it to
+non-decreasing in place, and `searchsorted`s the window-start/-end index arrays from the
+grid. All three arrays (`_t_full`, `_starts`, `_ends`) are cached on the instance so
+every subsequent `read_windows` call skips the file read and reuses the cached state.
+Because `_t_full` can reach ~2 GB for a Gen4 sequence, the arrays are excluded from
+pickle (`__getstate__` sets them to `None`); each DataLoader worker rebuilds its own copy
+lazily after fork/spawn. Only the small `_grid` array and the `label_source` carry
+through pickle intact.
+
 `PreprocessedH5Source` and `EvlibStreamSource` are interchangeable behind the dataset
 seam: the same dataset works with either.
+
+## Augmentation
+
+`SequenceAugmentor` applies RVT-matched spatial augmentation to a `SequenceSample`,
+transforming both the `[C, H, W]` uint8 event-representation tensors and their aligned
+yolox boxes together. The pipeline mirrors RVT's `RandomSpatialAugmentorGenX`: horizontal
+flip, rotation, zoom-in, and zoom-out, in that order. Padded windows (where
+`is_padded_mask[t]` is `True`) are returned unchanged. Boxes are stored in evlib's yolox
+centre form `[class_id, cx, cy, w, h]`; the augmentor converts to RVT's top-left form
+for each transform and converts back, so the arithmetic is byte-identical.
+
+```python
+class SequenceAugmentor:
+    def __init__(
+        self,
+        *,
+        sampler: str = "random",   # "random" (per-item) or "stream" (per-source)
+        prob_hflip: float = 0.5,
+        rotate_prob: float = 0.0,
+        rotate_min_deg: float = 2.0,
+        rotate_max_deg: float = 6.0,
+        zoom_prob: Optional[float] = None,  # default 0.8 for "random", 0.5 for "stream"
+        zoom_in_weight: int = 8,
+        zoom_out_weight: int = 2,
+        zoom_in_range: Tuple[float, float] = (1.0, 1.5),
+        zoom_out_range: Tuple[float, float] = (1.0, 1.2),
+        rng: Optional[np.random.Generator] = None,
+    ) -> None: ...
+
+    def __call__(self, sample: SequenceSample) -> SequenceSample: ...
+    def for_source(self, first_sample: SequenceSample) -> _FrozenAugmentor: ...
+```
+
+Two entry points reflect RVT's two augmentation semantics.
+
+`__call__` draws fresh parameters for each call, giving independent per-item
+randomisation. This is the right choice for `SequenceRandomDataset`, where every item is
+independent.
+
+`for_source(first_sample)` draws parameters once from the first chunk of a source and
+returns a `_FrozenAugmentor` callable. Every subsequent chunk from that source is
+augmented with the same frozen parameters, matching RVT's streaming semantics where a
+single random state is committed per source, not per chunk. This path requires zoom-in to
+be disabled (`zoom_in_weight=0` or `sampler="stream"`) because zoom-in is label-aware and
+cannot be computed without seeing the whole sequence.
+
+The `"stream"` sampler preset sets `zoom_in_weight=0`, `zoom_prob=0.5`, and
+`zoom_out_range=(1.0, 1.2)`.
+
+### Wiring into datasets and DataModule
+
+Pass `augmentor=` to either dataset class or to `EventDataModule`.
+
+`SequenceRandomDataset` calls `augmentor(sample)` per `__getitem__`, so fresh parameters
+are drawn for every item.
+
+`SequenceStreamDataset` calls `augmentor.for_source(first_chunk)` on the first chunk from
+each source and reuses the frozen result for all remaining chunks of that source.
+
+`EventDataModule` passes the `augmentor` only to the train dataloader. Validation and test
+dataloaders never receive it.
+
+```python
+from evlib.data import SequenceAugmentor, SequenceRandomDataset
+
+augmentor = SequenceAugmentor(sampler="random", prob_hflip=0.5, zoom_prob=0.8)
+dataset = SequenceRandomDataset([source], sequence_length=4, augmentor=augmentor)
+```
 
 ## Datasets
 
@@ -121,6 +200,118 @@ at a time.
 
 `custom_collate_stream` is the streaming-step collate: it takes a list of `batch_size`
 slot-aligned `SequenceSample`s and produces the same dict shape.
+
+## Label preprocessing from raw
+
+`evlib.data.label_preprocess` reproduces RVT's offline label preprocessing pipeline,
+turning a raw Prophesee `*_bbox.npy` structured array into the on-disk artifacts expected
+by `PreprocessedH5Source` and `EvlibStreamSource`. Output is byte-identical to RVT's
+`scripts/genx/preprocess_dataset.py` (verified by a local slow integration gate).
+
+### Constants and types
+
+```python
+BBOX_DTYPE   # numpy structured dtype: (t, x, y, w, h, class_id, class_confidence, track_id)
+LABEL_NPZ_FIELDS  # tuple of field names drawn from BBOX_DTYPE
+RVT_REPR_DIR_NAME = "stacked_histogram_dt=50_nbins=10"  # on-disk repr directory name (RVT form)
+
+class NoLabelsError(Exception): ...       # raised when all boxes are removed by filters
+```
+
+Note: `RVT_REPR_DIR_NAME` uses `=` separators to match RVT's on-disk layout. The
+`PreprocessedH5Source` default `repr_name` uses the no-`=` form
+`"stacked_histogram_dt50_nbins10"`; pass `repr_dir_name=RVT_REPR_DIR_NAME` when writing
+with `preprocess_sequence` and the corresponding value when constructing the source.
+
+### Core functions
+
+```python
+def read_raw_bbox(path: Union[str, Path]) -> np.ndarray:
+    """Load a raw *_bbox.npy and validate its fields against BBOX_DTYPE."""
+
+def apply_filters(
+    labels: np.ndarray,
+    *,
+    dataset: str = "gen4",
+    split: str,
+    height: int,
+    width: int,
+    apply_psee_bbox_filter: bool = False,
+    apply_faulty_bbox_filter: bool = True,
+) -> np.ndarray:
+    """Run RVT's filter chain in order.
+
+    Steps: (1) gen4 class removal (pedestrian/two-wheeler/car only), (2) crop-to-FOV,
+    (3) size filter (conservative w>=5 h>=5 for gen4, or Prophesee diag/side for gen1),
+    (4) faulty-huge removal (train split only). Raises NoLabelsError if no boxes survive.
+    """
+
+def build_objframes_and_grid(
+    filtered_labels: np.ndarray,
+    *,
+    dataset: str = "gen4",
+    delta_t_us: int = 50000,
+    align_t_us: int = 100000,
+    ts_step_frame_ms: int = 100,
+    ts_step_ev_repr_ms: int = 50,
+    jitter_us: int = 2000,
+) -> ObjframeGridResult:
+    """Select object frames, build the event-repr window-end grid, and align the two.
+
+    Returns an ObjframeGridResult dataclass with fields: labels, objframe_idx_2_label_idx,
+    frame_timestamps_us, ev_repr_timestamps_us_end, objframe_idx_2_repr_idx.
+    """
+
+def write_preprocessed(
+    out_dir: Union[str, Path],
+    result: ObjframeGridResult,
+    *,
+    repr_dir_name: str = RVT_REPR_DIR_NAME,
+) -> None:
+    """Write the RVT directory tree for one sequence.
+
+    Produces: labels_v2/labels.npz, labels_v2/timestamps_us.npy,
+    event_representations_v2/<repr_dir_name>/objframe_idx_2_repr_idx.npy,
+    event_representations_v2/<repr_dir_name>/timestamps_us.npy.
+    """
+
+def preprocess_sequence(
+    bbox_path: Union[str, Path],
+    out_dir: Union[str, Path],
+    *,
+    dataset: str = "gen4",
+    split: str = "val",
+    height: int = 720,
+    width: int = 1280,
+    repr_dir_name: str = RVT_REPR_DIR_NAME,
+) -> ObjframeGridResult:
+    """End-to-end pipeline: read -> filter -> grid -> write.
+
+    Ties read_raw_bbox -> apply_filters -> build_objframes_and_grid -> write_preprocessed.
+    Supported datasets: "gen4" (1280x720, default) and "gen1" (304x240).
+    """
+```
+
+### Typical usage
+
+```python
+from evlib.data import preprocess_sequence, RVT_REPR_DIR_NAME, PreprocessedH5Source
+
+result = preprocess_sequence(
+    "data/gen4/train/seq0/seq0_bbox.npy",
+    out_dir="data/gen4/train/seq0/",
+    dataset="gen4",
+    split="train",
+    height=720,
+    width=1280,
+)
+
+# The processed sequence is now readable by PreprocessedH5Source:
+source = PreprocessedH5Source(
+    "data/gen4/train/seq0/",
+    repr_name=RVT_REPR_DIR_NAME,
+)
+```
 
 ## Lightning DataModule (optional)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,8 @@ dev = [
 duckdb = ["duckdb >= 1.3.2"]
 jupyter = ["jupyter >= 1.0.0"]
 plot = ["matplotlib >= 3.7.0", "opencv-python>=4.8.0", "seaborn>=0.13.2",]
-torch = ["torch >= 2.0.0"]
-pytorch = ["torch >= 2.0.0"]
+torch = ["torch >= 2.0.0", "torchvision >= 0.15.0"]
+pytorch = ["torch >= 2.0.0", "torchvision >= 0.15.0"]
 
 # All
 all = [

--- a/python/evlib/__init__.py
+++ b/python/evlib/__init__.py
@@ -219,11 +219,6 @@ try:
 except ImportError:
     streaming_utils = None
 
-try:
-    from . import pytorch
-except ImportError:
-    pytorch = None
-
 # Import version
 try:
     __version__ = getattr(formats, "__version__", None)
@@ -560,7 +555,5 @@ if visualization:
 
 if streaming_utils:
     __all__.append("streaming_utils")
-if pytorch:
-    __all__.append("pytorch")
 if simulation:
     __all__.append("simulation")

--- a/python/evlib/data/__init__.py
+++ b/python/evlib/data/__init__.py
@@ -5,6 +5,13 @@ from evlib.data.collate import custom_collate_random, custom_collate_stream
 from evlib.data.dataset_random import SequenceRandomDataset
 from evlib.data.dataset_sample import SampleDataset
 from evlib.data.dataset_stream import SequenceStreamDataset
+from evlib.data.label_preprocess import (
+    BBOX_DTYPE,
+    LABEL_NPZ_FIELDS,
+    NoLabelsError,
+    apply_filters,
+    read_raw_bbox,
+)
 from evlib.data.labels import LABEL_FIELDS, boxes_to_yolox
 from evlib.data.sequence import DataKey, SequenceSample
 from evlib.data.sources import EvlibStreamSource, PreprocessedH5Source, ReprSource
@@ -15,6 +22,11 @@ __all__ = [
     "DataKey",
     "boxes_to_yolox",
     "LABEL_FIELDS",
+    "BBOX_DTYPE",
+    "LABEL_NPZ_FIELDS",
+    "NoLabelsError",
+    "read_raw_bbox",
+    "apply_filters",
     "ReprSource",
     "PreprocessedH5Source",
     "EvlibStreamSource",

--- a/python/evlib/data/__init__.py
+++ b/python/evlib/data/__init__.py
@@ -7,6 +7,7 @@ from evlib.data.dataset_sample import SampleDataset
 from evlib.data.dataset_stream import SequenceStreamDataset
 from evlib.data.label_preprocess import (
     BBOX_DTYPE,
+    EVLIB_REPR_DIR_NAME,
     LABEL_NPZ_FIELDS,
     RVT_REPR_DIR_NAME,
     NoLabelsError,
@@ -33,6 +34,7 @@ __all__ = [
     "NoLabelsError",
     "read_raw_bbox",
     "apply_filters",
+    "EVLIB_REPR_DIR_NAME",
     "RVT_REPR_DIR_NAME",
     "ObjframeGridResult",
     "build_objframes_and_grid",

--- a/python/evlib/data/__init__.py
+++ b/python/evlib/data/__init__.py
@@ -1,5 +1,12 @@
 """PyTorch data loading for event-vision training (sequences + samples)."""
 
+from evlib.data.ncaltech import (
+    NCALTECH_HEIGHT,
+    NCALTECH_WIDTH,
+    convert_ncaltech,
+    read_atis_bin,
+    representation_from_events,
+)
 from evlib.data.augment import SequenceAugmentor
 from evlib.data.collate import custom_collate_random, custom_collate_stream
 from evlib.data.dataset_random import SequenceRandomDataset
@@ -24,6 +31,11 @@ from evlib.data.sequence import DataKey, SequenceSample
 from evlib.data.sources import EvlibStreamSource, PreprocessedH5Source, ReprSource
 
 __all__ = [
+    "NCALTECH_HEIGHT",
+    "NCALTECH_WIDTH",
+    "convert_ncaltech",
+    "read_atis_bin",
+    "representation_from_events",
     "SequenceSample",
     "SequenceAugmentor",
     "DataKey",

--- a/python/evlib/data/__init__.py
+++ b/python/evlib/data/__init__.py
@@ -1,5 +1,6 @@
 """PyTorch data loading for event-vision training (sequences + samples)."""
 
+from evlib.data.augment import SequenceAugmentor
 from evlib.data.collate import custom_collate_random, custom_collate_stream
 from evlib.data.dataset_random import SequenceRandomDataset
 from evlib.data.dataset_sample import SampleDataset
@@ -10,6 +11,7 @@ from evlib.data.sources import EvlibStreamSource, PreprocessedH5Source, ReprSour
 
 __all__ = [
     "SequenceSample",
+    "SequenceAugmentor",
     "DataKey",
     "boxes_to_yolox",
     "LABEL_FIELDS",

--- a/python/evlib/data/__init__.py
+++ b/python/evlib/data/__init__.py
@@ -8,9 +8,15 @@ from evlib.data.dataset_stream import SequenceStreamDataset
 from evlib.data.label_preprocess import (
     BBOX_DTYPE,
     LABEL_NPZ_FIELDS,
+    RVT_REPR_DIR_NAME,
     NoLabelsError,
+    ObjframeGridResult,
     apply_filters,
+    build_objframes_and_grid,
+    get_base_delta_ts_us,
+    preprocess_sequence,
     read_raw_bbox,
+    write_preprocessed,
 )
 from evlib.data.labels import LABEL_FIELDS, boxes_to_yolox
 from evlib.data.sequence import DataKey, SequenceSample
@@ -27,6 +33,12 @@ __all__ = [
     "NoLabelsError",
     "read_raw_bbox",
     "apply_filters",
+    "RVT_REPR_DIR_NAME",
+    "ObjframeGridResult",
+    "build_objframes_and_grid",
+    "get_base_delta_ts_us",
+    "preprocess_sequence",
+    "write_preprocessed",
     "ReprSource",
     "PreprocessedH5Source",
     "EvlibStreamSource",

--- a/python/evlib/data/augment.py
+++ b/python/evlib/data/augment.py
@@ -450,14 +450,42 @@ class SequenceAugmentor:
                 return idx, box
         return None
 
-    # -- public entry point -------------------------------------------------
+    # -- public entry points ------------------------------------------------
 
     def __call__(self, sample: SequenceSample) -> SequenceSample:
+        """Draw fresh params for THIS sample and apply them (RVT random path)."""
         if len(sample.ev_repr) == 0:
             return sample
         sensor_hw = tuple(sample.ev_repr[0].shape[-2:])
         state = self._randomize(sensor_hw)
+        return self._apply(sample, state, sensor_hw)
 
+    def for_source(self, first_sample: SequenceSample) -> "_FrozenAugmentor":
+        """Draw input-independent params ONCE and return a per-chunk applier.
+
+        This mirrors RVT's streaming semantics: ``randomize_augmentation`` runs
+        once per stream/source and the same params (hflip, rotate, zoom-out)
+        apply to every chunk yielded from that source. Zoom-in is label-aware and
+        therefore unsupported in streaming, exactly as RVT asserts; the streaming
+        sampler preset already disables it (``zoom_in_weight=0``). The returned
+        callable applies the single frozen state to any chunk of this source.
+        """
+        sensor_hw = tuple(first_sample.ev_repr[0].shape[-2:])
+        state = self._randomize(sensor_hw)
+        if state.apply_zoom_in:
+            raise ValueError(
+                "for_source() requires zoom-in disabled (use sampler='stream' "
+                "or zoom_in_weight=0); zoom-in is label-aware and cannot be "
+                "frozen once per source"
+            )
+        return _FrozenAugmentor(self, state, sensor_hw)
+
+    def _apply(
+        self,
+        sample: SequenceSample,
+        state: _AugmentationState,
+        sensor_hw: Tuple[int, int],
+    ) -> SequenceSample:
         # The zoom-in window is label-aware: sample it once from the most-recent
         # non-empty frame and reuse it for every window (mirrors RVT).
         zoom_in_window: Optional[Tuple[int, int]] = None
@@ -519,3 +547,27 @@ class SequenceAugmentor:
             is_first_sample=sample.is_first_sample,
             is_padded_mask=list(sample.is_padded_mask),
         )
+
+
+class _FrozenAugmentor:
+    """Applies a single frozen augmentation state to every chunk of one source.
+
+    Returned by ``SequenceAugmentor.for_source``. The state was drawn once from
+    the source's first chunk; calling this on any later chunk reuses that exact
+    state, giving RVT's per-stream (not per-chunk) augmentation semantics.
+    """
+
+    def __init__(
+        self,
+        augmentor: SequenceAugmentor,
+        state: _AugmentationState,
+        sensor_hw: Tuple[int, int],
+    ) -> None:
+        self._augmentor = augmentor
+        self._state = state
+        self._sensor_hw = sensor_hw
+
+    def __call__(self, sample: SequenceSample) -> SequenceSample:
+        if len(sample.ev_repr) == 0:
+            return sample
+        return self._augmentor._apply(sample, self._state, self._sensor_hw)

--- a/python/evlib/data/augment.py
+++ b/python/evlib/data/augment.py
@@ -460,6 +460,17 @@ class SequenceAugmentor:
         state = self._randomize(sensor_hw)
         return self._apply(sample, state, sensor_hw)
 
+    def stream_safe(self) -> bool:
+        """True when this augmentor can be frozen once per source (no zoom-in).
+
+        Zoom-in is label-aware and cannot be frozen once per source, so an
+        augmentor that could ever draw it is unsafe for streaming. The single
+        condition that disables zoom-in is ``zoom_in_weight == 0`` (the
+        ``sampler='stream'`` preset sets exactly this); ``for_source`` enforces
+        the same invariant at draw time as a backstop.
+        """
+        return self.zoom_in_weight == 0
+
     def for_source(self, first_sample: SequenceSample) -> "_FrozenAugmentor":
         """Draw input-independent params ONCE and return a per-chunk applier.
 

--- a/python/evlib/data/augment.py
+++ b/python/evlib/data/augment.py
@@ -1,0 +1,521 @@
+"""Bbox-aware geometric augmentation for event-representation sequences.
+
+`SequenceAugmentor` reproduces RVT's training-time spatial augmentation
+(hflip -> rotate -> zoom_in -> zoom_out) on a single `SequenceSample`,
+transforming the `[C, H, W]` uint8 representation tensors AND their yolox boxes
+together. The exact tensor and box math mirrors the vendored RVT source:
+
+  - lib/RVT/data/utils/augmentor.py  (RandomSpatialAugmentorGenX)
+  - lib/RVT/data/genx_utils/labels.py (ObjectLabels in-place ops)
+
+evlib stores boxes in yolox CENTRE form ``[class_id, cx, cy, w, h]`` while RVT's
+math is written in TOP-LEFT ``[x, y, w, h]``. Each transform therefore converts
+centre -> top-left, applies RVT's exact op, then converts back to centre. NEAREST
+interpolation is used everywhere so the uint8 tensors are preserved exactly.
+Padded windows (``is_padded_mask[t]`` true) are returned untouched.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from torch.nn.functional import interpolate
+from torchvision.transforms import InterpolationMode
+from torchvision.transforms.functional import rotate as tv_rotate
+
+from evlib.data.sequence import SequenceSample
+
+__all__ = ["SequenceAugmentor"]
+
+
+@dataclass
+class _ZoomOutState:
+    active: bool
+    x0: int
+    y0: int
+    factor: float
+
+
+@dataclass
+class _AugmentationState:
+    apply_h_flip: bool
+    rotation_active: bool
+    rotation_angle_deg: float
+    apply_zoom_in: bool
+    zoom_in_factor: float
+    zoom_out: _ZoomOutState
+
+
+def _centre_to_topleft(box: torch.Tensor) -> torch.Tensor:
+    """[class_id, cx, cy, w, h] -> column stack [class_id, x, y, w, h] (top-left)."""
+    cls = box[:, 0]
+    cx = box[:, 1]
+    cy = box[:, 2]
+    w = box[:, 3]
+    h = box[:, 4]
+    x = cx - 0.5 * w
+    y = cy - 0.5 * h
+    return torch.stack([cls, x, y, w, h], dim=1)
+
+
+def _topleft_to_centre(cls, x, y, w, h) -> Optional[torch.Tensor]:
+    """Top-left arrays -> yolox centre tensor; None when no boxes remain."""
+    if x.numel() == 0:
+        return None
+    cx = x + 0.5 * w
+    cy = y + 0.5 * h
+    return torch.stack([cls, cx, cy, w, h], dim=1).to(torch.float32)
+
+
+class SequenceAugmentor:
+    """Sample augmentation params once per sequence and apply them to every window.
+
+    Parameter ranges default to RVT's ``sampler="random"`` config
+    (lib/RVT/config/dataset/base.yaml). Pass ``sampler="stream"`` for the
+    streaming preset (zoom-out only, lower zoom probability). All randomness flows
+    through a ``numpy.random.Generator`` so tests are deterministic.
+    """
+
+    def __init__(
+        self,
+        *,
+        sampler: str = "random",
+        prob_hflip: float = 0.5,
+        rotate_prob: float = 0.0,
+        rotate_min_deg: float = 2.0,
+        rotate_max_deg: float = 6.0,
+        zoom_prob: Optional[float] = None,
+        zoom_in_weight: int = 8,
+        zoom_out_weight: int = 2,
+        zoom_in_range: Tuple[float, float] = (1.0, 1.5),
+        zoom_out_range: Tuple[float, float] = (1.0, 1.2),
+        rng: Optional[np.random.Generator] = None,
+    ) -> None:
+        if sampler not in ("random", "stream"):
+            raise ValueError(f"sampler must be 'random' or 'stream', got {sampler!r}")
+        self.sampler = sampler
+
+        if sampler == "stream":
+            # Streaming preset: zoom-out only, lower zoom probability.
+            if zoom_prob is None:
+                zoom_prob = 0.5
+            zoom_in_weight = 0
+            zoom_out_range = (1.0, 1.2)
+        elif zoom_prob is None:
+            zoom_prob = 0.8
+
+        if not 0.0 <= prob_hflip <= 1.0:
+            raise ValueError("prob_hflip must be in [0, 1]")
+        if not 0.0 <= rotate_prob <= 1.0:
+            raise ValueError("rotate_prob must be in [0, 1]")
+        if not 0.0 <= zoom_prob <= 1.0:
+            raise ValueError("zoom_prob must be in [0, 1]")
+        if not 0.0 <= rotate_min_deg <= rotate_max_deg:
+            raise ValueError("require 0 <= rotate_min_deg <= rotate_max_deg")
+        if not zoom_in_range[1] >= zoom_in_range[0] >= 1.0:
+            raise ValueError("require zoom_in_range[1] >= zoom_in_range[0] >= 1")
+        if not zoom_out_range[1] >= zoom_out_range[0] >= 1.0:
+            raise ValueError("require zoom_out_range[1] >= zoom_out_range[0] >= 1")
+        if zoom_in_weight < 0 or zoom_out_weight < 0:
+            raise ValueError("zoom weights must be non-negative")
+        if zoom_in_weight + zoom_out_weight <= 0:
+            raise ValueError("at least one zoom weight must be positive")
+
+        self.prob_hflip = float(prob_hflip)
+        self.rotate_prob = float(rotate_prob)
+        self.rotate_min_deg = float(rotate_min_deg)
+        self.rotate_max_deg = float(rotate_max_deg)
+        self.zoom_prob = float(zoom_prob)
+        self.zoom_in_weight = int(zoom_in_weight)
+        self.zoom_out_weight = int(zoom_out_weight)
+        self.zoom_in_range = (float(zoom_in_range[0]), float(zoom_in_range[1]))
+        self.zoom_out_range = (float(zoom_out_range[0]), float(zoom_out_range[1]))
+        self.rng = rng if rng is not None else np.random.default_rng()
+
+    # -- parameter sampling -------------------------------------------------
+
+    def _uniform(self, low: float, high: float) -> float:
+        if high == low:
+            return low
+        return float(self.rng.uniform(low, high))
+
+    def _randomize(self, sensor_hw: Tuple[int, int]) -> _AugmentationState:
+        height, width = sensor_hw
+
+        apply_h_flip = self.prob_hflip > float(self.rng.random())
+
+        rotation_active = self.rotate_prob > float(self.rng.random())
+        rotation_angle_deg = 0.0
+        if rotation_active:
+            sign = 1.0 if self.rng.random() >= 0.5 else -1.0
+            rotation_angle_deg = sign * self._uniform(
+                self.rotate_min_deg, self.rotate_max_deg
+            )
+
+        do_zoom = self.zoom_prob > float(self.rng.random())
+        # Categorical over [zoom_in, zoom_out]; index 0 is zoom-in.
+        weights = np.array(
+            [self.zoom_in_weight, self.zoom_out_weight], dtype=np.float64
+        )
+        probs = weights / weights.sum()
+        do_zoom_in = int(self.rng.choice(2, p=probs)) == 0
+        do_zoom_out = not do_zoom_in
+        do_zoom_in = do_zoom_in and do_zoom
+        do_zoom_out = do_zoom_out and do_zoom
+
+        zoom_out = _ZoomOutState(active=False, x0=0, y0=0, factor=1.0)
+        if do_zoom_out:
+            factor = self._uniform(*self.zoom_out_range)
+            zoom_window_h = int(height / factor)
+            zoom_window_w = int(width / factor)
+            x0 = int(self._uniform(0, width - zoom_window_w))
+            y0 = int(self._uniform(0, height - zoom_window_h))
+            zoom_out = _ZoomOutState(active=True, x0=x0, y0=y0, factor=factor)
+
+        # zoom-in factor sampled here; its label-aware window is sampled later,
+        # once we know the most-recent non-empty frame (mirrors RVT).
+        zoom_in_factor = 1.0
+        if do_zoom_in:
+            zoom_in_factor = self._uniform(*self.zoom_in_range)
+
+        return _AugmentationState(
+            apply_h_flip=apply_h_flip,
+            rotation_active=rotation_active,
+            rotation_angle_deg=rotation_angle_deg,
+            apply_zoom_in=do_zoom_in,
+            zoom_in_factor=zoom_in_factor,
+            zoom_out=zoom_out,
+        )
+
+    # -- per-window tensor ops ---------------------------------------------
+
+    @staticmethod
+    def _flip_tensor(window: torch.Tensor) -> torch.Tensor:
+        return torch.flip(window, dims=[-1])
+
+    @staticmethod
+    def _rotate_tensor(window: torch.Tensor, angle_deg: float) -> torch.Tensor:
+        return tv_rotate(
+            window, angle=angle_deg, interpolation=InterpolationMode.NEAREST
+        )
+
+    @staticmethod
+    def _zoom_out_tensor(
+        window: torch.Tensor, x0: int, y0: int, factor: float
+    ) -> torch.Tensor:
+        height, width = window.shape[-2:]
+        zoom_window_h = int(height / factor)
+        zoom_window_w = int(width / factor)
+        shrunk = interpolate(
+            window.unsqueeze(0).float(),
+            size=(zoom_window_h, zoom_window_w),
+            mode="nearest-exact",
+        )[0].to(window.dtype)
+        out = torch.zeros_like(window)
+        out[:, y0 : y0 + zoom_window_h, x0 : x0 + zoom_window_w] = shrunk
+        return out
+
+    @staticmethod
+    def _zoom_in_tensor(
+        window: torch.Tensor, x0: int, y0: int, factor: float
+    ) -> torch.Tensor:
+        height, width = window.shape[-2:]
+        zoom_window_h = int(height / factor)
+        zoom_window_w = int(width / factor)
+        crop = window[..., y0 : y0 + zoom_window_h, x0 : x0 + zoom_window_w].unsqueeze(
+            0
+        )
+        out = interpolate(crop.float(), size=(height, width), mode="nearest-exact")[
+            0
+        ].to(window.dtype)
+        return out
+
+    # -- per-window box ops (top-left math, mirrors RVT ObjectLabels) -------
+
+    @staticmethod
+    def _flip_box(box: torch.Tensor, width: int) -> Optional[torch.Tensor]:
+        tl = _centre_to_topleft(box)
+        cls, x, y, w, h = tl[:, 0], tl[:, 1], tl[:, 2], tl[:, 3], tl[:, 4]
+        x = (width - 1) - x - w  # flip_lr_
+        return _topleft_to_centre(cls, x, y, w, h)
+
+    @staticmethod
+    def _rotate_box(
+        box: torch.Tensor, sensor_hw: Tuple[int, int], angle_deg: float
+    ) -> Optional[torch.Tensor]:
+        height, width = sensor_hw
+        tl = _centre_to_topleft(box)
+        cls, x, y, w, h = tl[:, 0], tl[:, 1], tl[:, 2], tl[:, 3], tl[:, 4]
+
+        p00 = torch.stack((x, y), dim=1)
+        p10 = torch.stack((x + w, y), dim=1)
+        p01 = torch.stack((x, y + h), dim=1)
+        p11 = torch.stack((x + w, y + h), dim=1)
+        points = torch.stack((p00, p10, p01, p11), dim=0)  # 4 x N x 2
+
+        cx = width // 2
+        cy = height // 2
+        centre = torch.tensor([cx, cy], dtype=points.dtype)
+
+        angle_rad = angle_deg / 180.0 * math.pi
+        rot = torch.tensor(
+            [
+                [math.cos(angle_rad), math.sin(angle_rad)],
+                [-math.sin(angle_rad), math.cos(angle_rad)],
+            ],
+            dtype=points.dtype,
+        )
+        points = points - centre
+        points = torch.einsum("ij,pnj->pni", rot, points)
+        points = points + centre
+
+        x0 = torch.clamp(torch.min(points[..., 0], dim=0)[0], min=0, max=width - 1)
+        y0 = torch.clamp(torch.min(points[..., 1], dim=0)[0], min=0, max=height - 1)
+        x1 = torch.clamp(torch.max(points[..., 0], dim=0)[0], min=0, max=width - 1)
+        y1 = torch.clamp(torch.max(points[..., 1], dim=0)[0], min=0, max=height - 1)
+
+        new_x = x0
+        new_y = y0
+        new_w = x1 - x0
+        new_h = y1 - y0
+        keep = (new_w > 0) & (new_h > 0)  # remove_flat_labels_
+        return _topleft_to_centre(
+            cls[keep], new_x[keep], new_y[keep], new_w[keep], new_h[keep]
+        )
+
+    @staticmethod
+    def _scale_box(
+        cls, x, y, w, h, sensor_hw: Tuple[float, float], multiplier: float
+    ) -> Tuple:
+        """RVT ObjectLabels.scale_: scale in place and drop flat boxes.
+
+        Returns the new (cls, x, y, w, h, new_sensor_hw).
+        """
+        img_ht, img_wd = sensor_hw
+        new_img_ht = multiplier * img_ht
+        new_img_wd = multiplier * img_wd
+        x1 = torch.clamp((x + w) * multiplier, max=new_img_wd - 1)
+        y1 = torch.clamp((y + h) * multiplier, max=new_img_ht - 1)
+        x = x * multiplier
+        y = y * multiplier
+        w = x1 - x
+        h = y1 - y
+        keep = (w > 0) & (h > 0)
+        return (
+            cls[keep],
+            x[keep],
+            y[keep],
+            w[keep],
+            h[keep],
+            (new_img_ht, new_img_wd),
+        )
+
+    @classmethod
+    def _zoom_out_box(
+        cls_self,
+        box: torch.Tensor,
+        sensor_hw: Tuple[int, int],
+        x0: int,
+        y0: int,
+        factor: float,
+    ) -> Optional[torch.Tensor]:
+        tl = _centre_to_topleft(box)
+        cls, x, y, w, h = tl[:, 0], tl[:, 1], tl[:, 2], tl[:, 3], tl[:, 4]
+        h_orig, w_orig = sensor_hw
+        cls, x, y, w, h, _ = cls_self._scale_box(
+            cls, x, y, w, h, (h_orig, w_orig), 1.0 / factor
+        )
+        # input_size restored to (h_orig, w_orig); translate by (x0, y0).
+        x = x + x0
+        y = y + y0
+        return _topleft_to_centre(cls, x, y, w, h)
+
+    @classmethod
+    def _zoom_in_box(
+        cls_self,
+        box: torch.Tensor,
+        sensor_hw: Tuple[int, int],
+        z_x0: int,
+        z_y0: int,
+        factor: float,
+    ) -> Optional[torch.Tensor]:
+        tl = _centre_to_topleft(box)
+        cls, x, y, w, h = tl[:, 0], tl[:, 1], tl[:, 2], tl[:, 3], tl[:, 4]
+        h_orig, w_orig = sensor_hw
+        zoom_window_h = h_orig / factor
+        zoom_window_w = w_orig / factor
+        z_x1 = min(z_x0 + zoom_window_w, w_orig - 1)
+        z_y1 = min(z_y0 + zoom_window_h, h_orig - 1)
+
+        x0 = torch.clamp(x, min=z_x0, max=z_x1 - 1)
+        y0 = torch.clamp(y, min=z_y0, max=z_y1 - 1)
+        x1 = torch.clamp(x + w, min=z_x0, max=z_x1 - 1)
+        y1 = torch.clamp(y + h, min=z_y0, max=z_y1 - 1)
+
+        new_x = x0 - z_x0
+        new_y = y0 - z_y0
+        new_w = x1 - x0
+        new_h = y1 - y0
+        keep = (new_w > 0) & (new_h > 0)  # remove_flat_labels_
+        cls, new_x, new_y, new_w, new_h = (
+            cls[keep],
+            new_x[keep],
+            new_y[keep],
+            new_w[keep],
+            new_h[keep],
+        )
+        # scale_ back to full resolution by factor.
+        cls, new_x, new_y, new_w, new_h, _ = cls_self._scale_box(
+            cls, new_x, new_y, new_w, new_h, (zoom_window_h, zoom_window_w), factor
+        )
+        return _topleft_to_centre(cls, new_x, new_y, new_w, new_h)
+
+    # -- label-aware zoom-in window sampling (mirrors RVT) ------------------
+
+    def _sample_zoom_in_window(
+        self,
+        box: torch.Tensor,
+        sensor_hw: Tuple[int, int],
+        zoom_window_h: int,
+        zoom_window_w: int,
+    ) -> Tuple[int, int]:
+        height, width = sensor_hw
+        tl = _centre_to_topleft(box)
+        candidates: List[Tuple[int, int]] = []
+        for idx in range(tl.shape[0]):
+            x0_l = float(tl[idx, 1])
+            y0_l = float(tl[idx, 2])
+            w_l = float(tl[idx, 3])
+            h_l = float(tl[idx, 4])
+            candidates.append(
+                self._zoom_window_from_label_rectangle(
+                    x0_l,
+                    y0_l,
+                    w_l,
+                    h_l,
+                    height,
+                    width,
+                    zoom_window_h,
+                    zoom_window_w,
+                )
+            )
+        assert len(candidates) > 0
+        if len(candidates) == 1:
+            sample_idx = 0
+        else:
+            # RVT: th.randint(low=0, high=len(candidates) - 1). The upper bound
+            # is exclusive, matching the (arguably off-by-one) RVT behaviour.
+            sample_idx = int(self.rng.integers(0, len(candidates) - 1))
+        return candidates[sample_idx]
+
+    def _zoom_window_from_label_rectangle(
+        self,
+        x0_l: float,
+        y0_l: float,
+        w_l: float,
+        h_l: float,
+        input_height: int,
+        input_width: int,
+        zoom_window_height: int,
+        zoom_window_width: int,
+    ) -> Tuple[int, int]:
+        x1_l = x0_l + w_l
+        y1_l = y0_l + h_l
+
+        x0_valid = max(x1_l - max(zoom_window_width, w_l), 0)
+        y0_valid = max(y1_l - max(zoom_window_height, h_l), 0)
+        x1_valid = min(x0_l + max(zoom_window_width, w_l), input_width - 1)
+        y1_valid = min(y0_l + max(zoom_window_height, h_l), input_height - 1)
+
+        x1_valid = max(x1_valid - zoom_window_width, x0_valid)
+        y1_valid = max(y1_valid - zoom_window_height, y0_valid)
+
+        x_topleft = int(self._uniform(x0_valid, x1_valid))
+        y_topleft = int(self._uniform(y0_valid, y1_valid))
+        return x_topleft, y_topleft
+
+    @staticmethod
+    def _most_recent_nonempty(
+        sample: SequenceSample,
+    ) -> Optional[Tuple[int, torch.Tensor]]:
+        for idx in range(len(sample.labels) - 1, -1, -1):
+            if sample.is_padded_mask[idx]:
+                continue
+            box = sample.labels[idx]
+            if box is not None and box.shape[0] > 0:
+                return idx, box
+        return None
+
+    # -- public entry point -------------------------------------------------
+
+    def __call__(self, sample: SequenceSample) -> SequenceSample:
+        if len(sample.ev_repr) == 0:
+            return sample
+        sensor_hw = tuple(sample.ev_repr[0].shape[-2:])
+        state = self._randomize(sensor_hw)
+
+        # The zoom-in window is label-aware: sample it once from the most-recent
+        # non-empty frame and reuse it for every window (mirrors RVT).
+        zoom_in_window: Optional[Tuple[int, int]] = None
+        if state.apply_zoom_in and state.zoom_in_factor != 1.0:
+            latest = self._most_recent_nonempty(sample)
+            if latest is None:
+                # RVT warns and skips zoom-in when no labels are present.
+                state.apply_zoom_in = False
+            else:
+                _, latest_box = latest
+                height, width = sensor_hw
+                zoom_window_h = int(height / state.zoom_in_factor)
+                zoom_window_w = int(width / state.zoom_in_factor)
+                zoom_in_window = self._sample_zoom_in_window(
+                    latest_box, sensor_hw, zoom_window_h, zoom_window_w
+                )
+
+        new_ev_repr: List[torch.Tensor] = []
+        new_labels: List[Optional[torch.Tensor]] = []
+
+        for idx, window in enumerate(sample.ev_repr):
+            if sample.is_padded_mask[idx]:
+                new_ev_repr.append(window)
+                new_labels.append(sample.labels[idx])
+                continue
+
+            box = sample.labels[idx]
+            win = window
+
+            if state.apply_h_flip:
+                win = self._flip_tensor(win)
+                if box is not None:
+                    box = self._flip_box(box, sensor_hw[1])
+
+            if state.rotation_active:
+                win = self._rotate_tensor(win, state.rotation_angle_deg)
+                if box is not None:
+                    box = self._rotate_box(box, sensor_hw, state.rotation_angle_deg)
+
+            if state.apply_zoom_in and zoom_in_window is not None:
+                z_x0, z_y0 = zoom_in_window
+                win = self._zoom_in_tensor(win, z_x0, z_y0, state.zoom_in_factor)
+                if box is not None:
+                    box = self._zoom_in_box(
+                        box, sensor_hw, z_x0, z_y0, state.zoom_in_factor
+                    )
+            elif state.zoom_out.active:
+                z = state.zoom_out
+                win = self._zoom_out_tensor(win, z.x0, z.y0, z.factor)
+                if box is not None:
+                    box = self._zoom_out_box(box, sensor_hw, z.x0, z.y0, z.factor)
+
+            new_ev_repr.append(win)
+            new_labels.append(box)
+
+        return SequenceSample(
+            ev_repr=new_ev_repr,
+            labels=new_labels,
+            is_first_sample=sample.is_first_sample,
+            is_padded_mask=list(sample.is_padded_mask),
+        )

--- a/python/evlib/data/datamodule.py
+++ b/python/evlib/data/datamodule.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Callable, List, Optional
 
 from torch.utils.data import DataLoader
 
@@ -30,6 +30,7 @@ if _HAS_LIGHTNING:
             batch_size: int,
             num_workers: int = 4,
             sampling: str = "random",
+            augmentor: Optional[Callable] = None,
         ) -> None:
             super().__init__()
             self.train_sources = train_sources
@@ -38,17 +39,27 @@ if _HAS_LIGHTNING:
             self.batch_size = batch_size
             self.num_workers = num_workers
             self.sampling = sampling
+            # Augmentation is a TRAIN-only concern (RVT builds the augmentor for
+            # the train split alone); val/test datasets never receive it.
+            self.augmentor = augmentor
 
         def train_dataloader(self) -> DataLoader:
             if self.sampling == "stream":
-                ds = SequenceStreamDataset(self.train_sources, self.L, self.batch_size)
+                ds = SequenceStreamDataset(
+                    self.train_sources,
+                    self.L,
+                    self.batch_size,
+                    augmentor=self.augmentor,
+                )
                 return DataLoader(
                     ds,
                     batch_size=None,
                     num_workers=self.num_workers,
                     collate_fn=custom_collate_stream,
                 )
-            ds = SequenceRandomDataset(self.train_sources, self.L)
+            ds = SequenceRandomDataset(
+                self.train_sources, self.L, augmentor=self.augmentor
+            )
             return DataLoader(
                 ds,
                 batch_size=self.batch_size,

--- a/python/evlib/data/dataset_random.py
+++ b/python/evlib/data/dataset_random.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import torch
 from torch.utils.data import Dataset
@@ -12,11 +12,19 @@ from evlib.data.sources import ReprSource
 
 
 class SequenceRandomDataset(Dataset):
-    def __init__(self, sources: List[ReprSource], sequence_length: int) -> None:
+    def __init__(
+        self,
+        sources: List[ReprSource],
+        sequence_length: int,
+        augmentor: Optional[Callable[[SequenceSample], SequenceSample]] = None,
+    ) -> None:
         if sequence_length < 1:
             raise ValueError("sequence_length must be >= 1")
         self.sources = sources
         self.L = sequence_length
+        # Optional opt-in augmentor: fresh params are drawn PER __getitem__
+        # (RVT random semantics), so a plain augmentor(sample) call is correct.
+        self.augmentor = augmentor
         # index map: (source_idx, start_window) for each sequence
         self._index: List[Tuple[int, int]] = []
         for si, src in enumerate(sources):
@@ -40,6 +48,9 @@ class SequenceRandomDataset(Dataset):
             zero = torch.zeros_like(ev[0])
             ev = ev + [zero.clone() for _ in range(pad)]
             labels = labels + [None] * pad
-        return SequenceSample(
+        sample = SequenceSample(
             ev, labels, is_first_sample=True, is_padded_mask=is_padded
         )
+        if self.augmentor is not None:
+            sample = self.augmentor(sample)
+        return sample

--- a/python/evlib/data/dataset_stream.py
+++ b/python/evlib/data/dataset_stream.py
@@ -64,6 +64,19 @@ class SequenceStreamDataset(IterableDataset):
         self.batch_size = batch_size
         # Optional opt-in augmentor: params are drawn ONCE per source and reused
         # across all its chunks (RVT stream semantics); see _stream_one_source.
+        # An augmentor that could ever draw label-aware zoom-in cannot be frozen
+        # per source, so reject it EAGERLY here rather than failing mid-iteration
+        # when for_source() first draws zoom-in. The streaming-safe condition is
+        # the same one for_source enforces (zoom-in disabled), exposed as
+        # stream_safe(); for_source keeps its own guard as a backstop.
+        if augmentor is not None and hasattr(augmentor, "stream_safe"):
+            if not augmentor.stream_safe():
+                raise ValueError(
+                    "SequenceStreamDataset requires a stream-safe augmentor "
+                    "(zoom-in disabled, e.g. sampler='stream' or "
+                    "zoom_in_weight=0); zoom-in is label-aware and cannot be "
+                    "frozen once per source"
+                )
         self.augmentor = augmentor
 
     def __iter__(self) -> Iterator[List[SequenceSample]]:

--- a/python/evlib/data/dataset_stream.py
+++ b/python/evlib/data/dataset_stream.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterator, List
+from typing import Callable, Iterator, List, Optional
 
 import torch
 from torch.utils.data import IterableDataset, get_worker_info
@@ -11,9 +11,24 @@ from evlib.data.sequence import SequenceSample
 from evlib.data.sources import ReprSource
 
 
-def _stream_one_source(src: ReprSource, L: int) -> Iterator[SequenceSample]:
+def _stream_one_source(
+    src: ReprSource,
+    L: int,
+    augmentor: Optional[Callable] = None,
+) -> Iterator[SequenceSample]:
+    """Yield this source's ordered chunks, optionally augmenting them.
+
+    RVT stream semantics: augmentation params are drawn ONCE per source and the
+    SAME params apply to every chunk yielded from it. The frozen applier is built
+    from the first chunk via ``augmentor.for_source(first_chunk)`` and reused for
+    all subsequent chunks of this source. The trailing padded chunk (when the
+    source length is not a multiple of L) is real data plus padding, so it is
+    augmented like any other; only the all-padded placeholder samples that
+    ``__iter__`` synthesises for exhausted slots are left untouched.
+    """
     n = src.window_count()
     first = True
+    frozen = None
     for start in range(0, n, L):
         hi = min(start + L, n)
         ev, labels = src.read_windows(start, hi)
@@ -24,19 +39,32 @@ def _stream_one_source(src: ReprSource, L: int) -> Iterator[SequenceSample]:
             zero = torch.zeros_like(ev[0])
             ev = ev + [zero.clone() for _ in range(pad)]
             labels = labels + [None] * pad
-        yield SequenceSample(
+        sample = SequenceSample(
             ev, labels, is_first_sample=first, is_padded_mask=is_padded
         )
+        if augmentor is not None:
+            if frozen is None:
+                # Draw the single per-source param state from the first chunk.
+                frozen = augmentor.for_source(sample)
+            sample = frozen(sample)
+        yield sample
         first = False
 
 
 class SequenceStreamDataset(IterableDataset):
     def __init__(
-        self, sources: List[ReprSource], sequence_length: int, batch_size: int
+        self,
+        sources: List[ReprSource],
+        sequence_length: int,
+        batch_size: int,
+        augmentor: Optional[Callable] = None,
     ) -> None:
         self.sources = sources
         self.L = sequence_length
         self.batch_size = batch_size
+        # Optional opt-in augmentor: params are drawn ONCE per source and reused
+        # across all its chunks (RVT stream semantics); see _stream_one_source.
+        self.augmentor = augmentor
 
     def __iter__(self) -> Iterator[List[SequenceSample]]:
         info = get_worker_info()
@@ -54,7 +82,7 @@ class SequenceStreamDataset(IterableDataset):
 
         def slot_iter(slot_sources):
             for s in slot_sources:
-                yield from _stream_one_source(s, self.L)
+                yield from _stream_one_source(s, self.L, self.augmentor)
 
         num_slots = self.batch_size
         iters = [slot_iter(s) for s in slots]

--- a/python/evlib/data/label_preprocess.py
+++ b/python/evlib/data/label_preprocess.py
@@ -18,11 +18,17 @@ from typing import Union
 import numpy as np
 
 # RVT's on-disk representation directory name carries ``=`` separators
-# (``stacked_histogram_dt=50_nbins=10``), whereas evlib's phase-1 ``REPR_NAME``
-# in ``evlib.data.sources`` uses ``stacked_histogram_dt50_nbins10`` (no ``=``).
-# For byte-identical reproduction of RVT's output tree this writer defaults to
-# the RVT form; reconciling the two naming schemes is a separate concern.
+# (``stacked_histogram_dt=50_nbins=10``).  Pass this constant as
+# ``repr_dir_name`` when reproducing RVT's upstream on-disk layout.
 RVT_REPR_DIR_NAME = "stacked_histogram_dt=50_nbins=10"
+
+# evlib-native form: no ``=`` separators.  This is the default for
+# ``write_preprocessed`` and ``preprocess_sequence`` so that output written by
+# those functions is readable by the default ``PreprocessedH5Source`` and
+# ``EvlibStreamSource`` without any extra configuration.
+# Must match evlib.data.sources.REPR_NAME and evlib.rvt.pipeline.REPR_NAME --
+# kept as a standalone literal to avoid pulling torch into this module.
+EVLIB_REPR_DIR_NAME = "stacked_histogram_dt50_nbins10"
 
 # Verified on-disk schema from the staged real data. The field order is
 # load-bearing: B2/B3 write ``labels.npz`` from arrays of exactly this dtype.
@@ -364,7 +370,7 @@ def write_preprocessed(
     out_dir: Union[str, Path],
     result: ObjframeGridResult,
     *,
-    repr_dir_name: str = RVT_REPR_DIR_NAME,
+    repr_dir_name: str = EVLIB_REPR_DIR_NAME,
 ) -> None:
     """Lay down the RVT directory tree for one sequence.
 
@@ -406,7 +412,7 @@ def preprocess_sequence(
     split: str = "val",
     height: int = 720,
     width: int = 1280,
-    repr_dir_name: str = RVT_REPR_DIR_NAME,
+    repr_dir_name: str = EVLIB_REPR_DIR_NAME,
 ) -> ObjframeGridResult:
     """Read a raw bbox file, filter, align, and write the RVT artifacts.
 

--- a/python/evlib/data/label_preprocess.py
+++ b/python/evlib/data/label_preprocess.py
@@ -11,10 +11,18 @@ filter, matching the real on-disk schema.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Union
 
 import numpy as np
+
+# RVT's on-disk representation directory name carries ``=`` separators
+# (``stacked_histogram_dt=50_nbins=10``), whereas evlib's phase-1 ``REPR_NAME``
+# in ``evlib.data.sources`` uses ``stacked_histogram_dt50_nbins10`` (no ``=``).
+# For byte-identical reproduction of RVT's output tree this writer defaults to
+# the RVT form; reconciling the two naming schemes is a separate concern.
+RVT_REPR_DIR_NAME = "stacked_histogram_dt=50_nbins=10"
 
 # Verified on-disk schema from the staged real data. The field order is
 # load-bearing: B2/B3 write ``labels.npz`` from arrays of exactly this dtype.
@@ -189,3 +197,230 @@ def apply_filters(
             f"all boxes removed by the filter chain (dataset={dataset}, split={split})"
         )
     return labels
+
+
+def get_base_delta_ts_us(unique_ts_us: np.ndarray, dataset: str = "gen4") -> int:
+    """Base label cadence in microseconds (RVT ``get_base_delta_ts_for_labels_us``).
+
+    gen1 is a fixed 4 Hz cadence (``250000`` us). gen4 infers the dense label
+    cadence from ``median(diff(unique_ts))``, asserts it is 30 or 60 Hz, then
+    scales by 3 (30 Hz) or 6 (60 Hz) to approximate the 10 Hz object-frame rate.
+    (Lines 291-303.)
+    """
+    if dataset == "gen1":
+        return 250000
+    if dataset != "gen4":
+        raise ValueError(f"unknown dataset {dataset!r}")
+    diff_us = np.diff(unique_ts_us)
+    median_diff_us = np.median(diff_us)
+    hz = int(np.rint(10**6 / median_diff_us))
+    if hz not in {30, 60}:
+        raise ValueError(f"inferred label cadence {hz} Hz; expected 30 or 60")
+    return int(6 * median_diff_us if hz == 60 else 3 * median_diff_us)
+
+
+@dataclass
+class ObjframeGridResult:
+    """Aligned object-frame and event-representation-grid artifacts.
+
+    All index/timestamp arrays are int64, matching RVT's on-disk dtypes.
+
+    - ``labels``: the per-object-frame-grouped boxes, concatenated in frame
+      order (structured ``BBOX_DTYPE`` array).
+    - ``objframe_idx_2_label_idx``: cumulative per-frame start offsets into
+      ``labels`` (one entry per object frame).
+    - ``frame_timestamps_us``: the selected object-frame timestamps.
+    - ``ev_repr_timestamps_us_end``: the window-end grid for event reprs.
+    - ``objframe_idx_2_repr_idx``: ``searchsorted`` of the frame timestamps into
+      the grid; ``frame_timestamps_us == grid[objframe_idx_2_repr_idx]`` exactly.
+    """
+
+    labels: np.ndarray
+    objframe_idx_2_label_idx: np.ndarray
+    frame_timestamps_us: np.ndarray
+    ev_repr_timestamps_us_end: np.ndarray
+    objframe_idx_2_repr_idx: np.ndarray
+
+
+def build_objframes_and_grid(
+    filtered_labels: np.ndarray,
+    *,
+    dataset: str = "gen4",
+    delta_t_us: int = 50000,
+    align_t_us: int = 100000,
+    ts_step_frame_ms: int = 100,
+    ts_step_ev_repr_ms: int = 50,
+    jitter_us: int = 2000,
+) -> ObjframeGridResult:
+    """Select object frames, build the window-end grid, and align the two.
+
+    Transcribes RVT's ``labels_and_ev_repr_timestamps`` (lines 340-432) minus the
+    file IO. ``filtered_labels`` must be the output of :func:`apply_filters` and,
+    like RVT's input, be sorted by ``t`` (the grouping uses ``searchsorted`` on
+    ``t``, lines 390-391).
+    """
+    if ts_step_frame_ms < ts_step_ev_repr_ms or ts_step_ev_repr_ms <= 0:
+        raise ValueError("require ts_step_frame_ms >= ts_step_ev_repr_ms > 0")
+    if ts_step_frame_ms % ts_step_ev_repr_ms != 0:
+        raise ValueError("ts_step_frame_ms must be a multiple of ts_step_ev_repr_ms")
+
+    label_ts = np.asarray(filtered_labels["t"], dtype="int64")
+    unique_ts_us = np.unique(label_ts)
+
+    base_delta_us = get_base_delta_ts_us(unique_ts_us, dataset)
+
+    # First unique timestamp at or after the alignment time (line 371).
+    first_idx = int(np.searchsorted(unique_ts_us, align_t_us, side="left"))
+
+    # Walk forward, accepting a timestamp when its gap to the previously accepted
+    # frame rounds to an integer multiple of base_delta within the jitter
+    # tolerance (lines 374-388). The per-gap event-repr count uses the
+    # frame/ev-repr step ratio (ts_step_frame_ms // ts_step_ev_repr_ms == 2).
+    repr_step_ratio = ts_step_frame_ms // ts_step_ev_repr_ms
+    num_ev_reprs_between = []
+    frame_timestamps = [int(unique_ts_us[first_idx])]
+    for idx in range(first_idx + 1, len(unique_ts_us)):
+        reference_time = frame_timestamps[-1]
+        ts = int(unique_ts_us[idx])
+        diff_to_ref = ts - reference_time
+        base_delta_count = round(diff_to_ref / base_delta_us)
+        diff_to_ref_rounded = base_delta_count * base_delta_us
+        if abs(diff_to_ref - diff_to_ref_rounded) <= jitter_us:
+            if base_delta_count <= 0:
+                raise ValueError(
+                    "accepted frame with non-positive base_delta_count "
+                    f"(diff_to_ref={diff_to_ref}, base_delta_us={base_delta_us})"
+                )
+            frame_timestamps.append(ts)
+            num_ev_reprs_between.append(base_delta_count * repr_step_ratio)
+    frame_timestamps_us = np.asarray(frame_timestamps, dtype="int64")
+
+    # Group boxes into object frames via the searchsorted boundaries on the
+    # sorted label timestamps (lines 390-399). RVT relies on the labels being
+    # time-sorted; all boxes inside a frame share a single timestamp.
+    start_indices = np.searchsorted(label_ts, frame_timestamps_us, side="left")
+    end_indices = np.searchsorted(label_ts, frame_timestamps_us, side="right")
+    labels_per_frame = []
+    objframe_idx_2_label_idx = []
+    start_offset = 0
+    for idx_start, idx_end in zip(start_indices, end_indices):
+        boxes = filtered_labels[idx_start:idx_end]
+        frame_time = int(boxes["t"][0])
+        if not np.all(np.asarray(boxes["t"], dtype="int64") == frame_time):
+            raise ValueError("boxes grouped into a frame have differing timestamps")
+        labels_per_frame.append(boxes)
+        objframe_idx_2_label_idx.append(start_offset)
+        start_offset += len(boxes)
+    grouped_labels = np.concatenate(labels_per_frame)
+    objframe_idx_2_label_idx = np.asarray(objframe_idx_2_label_idx, dtype="int64")
+
+    if len(frame_timestamps_us) > 1:
+        min_gap = int(np.diff(frame_timestamps_us).min())
+        if min_gap <= 98000:
+            raise ValueError(f"selected frames too close together (min gap {min_gap})")
+
+    # Window-end grid: pre-fill from the first frame backwards toward 0 in
+    # -delta_t_us steps, dropping the 0 and first-frame edges (line 405), then
+    # linspace each consecutive frame pair, dropping the shared edge between
+    # segments (lines 408-419).
+    grid = list(reversed(range(int(frame_timestamps_us[0]), 0, -delta_t_us)))[1:-1]
+    if len(num_ev_reprs_between) != len(frame_timestamps_us) - 1:
+        raise ValueError("num_ev_reprs_between length inconsistent with frames")
+    for idx, (num_between, frame_start, frame_end) in enumerate(
+        zip(num_ev_reprs_between, frame_timestamps_us[:-1], frame_timestamps_us[1:])
+    ):
+        edges = np.asarray(
+            np.linspace(frame_start, frame_end, num_between + 1), dtype="int64"
+        ).tolist()
+        is_last = idx == len(num_ev_reprs_between) - 1
+        if not is_last:
+            edges = edges[:-1]
+        grid.extend(edges)
+    if len(frame_timestamps_us) == 1:
+        # No linspace iterations run; append the single frame edge directly.
+        grid.append(int(frame_timestamps_us[0]))
+    ev_repr_timestamps_us_end = np.asarray(grid, dtype="int64")
+
+    objframe_idx_2_repr_idx = np.searchsorted(
+        ev_repr_timestamps_us_end, frame_timestamps_us, side="left"
+    ).astype("int64")
+
+    # Sanity checks (lines 426-430): the grid must land exactly on every frame.
+    if not np.array_equal(
+        frame_timestamps_us, ev_repr_timestamps_us_end[objframe_idx_2_repr_idx]
+    ):
+        raise ValueError("grid does not land exactly on the frame timestamps")
+
+    return ObjframeGridResult(
+        labels=grouped_labels,
+        objframe_idx_2_label_idx=objframe_idx_2_label_idx,
+        frame_timestamps_us=frame_timestamps_us,
+        ev_repr_timestamps_us_end=ev_repr_timestamps_us_end,
+        objframe_idx_2_repr_idx=objframe_idx_2_repr_idx,
+    )
+
+
+def write_preprocessed(
+    out_dir: Union[str, Path],
+    result: ObjframeGridResult,
+    *,
+    repr_dir_name: str = RVT_REPR_DIR_NAME,
+) -> None:
+    """Lay down the RVT directory tree for one sequence.
+
+    Mirrors RVT's ``save_labels`` (lines 306-337) and ``write_event_data``
+    (lines 435-464), writing:
+
+    - ``labels_v2/labels.npz`` with ``labels`` and ``objframe_idx_2_label_idx``,
+    - ``labels_v2/timestamps_us.npy`` (the frame timestamps),
+    - ``event_representations_v2/<repr_dir_name>/objframe_idx_2_repr_idx.npy``,
+    - ``event_representations_v2/<repr_dir_name>/timestamps_us.npy`` (the grid).
+    """
+    out_dir = Path(out_dir)
+    labels_dir = out_dir / "labels_v2"
+    repr_dir = out_dir / "event_representations_v2" / repr_dir_name
+    labels_dir.mkdir(parents=True, exist_ok=True)
+    repr_dir.mkdir(parents=True, exist_ok=True)
+
+    np.savez(
+        str(labels_dir / "labels.npz"),
+        labels=result.labels,
+        objframe_idx_2_label_idx=result.objframe_idx_2_label_idx,
+    )
+    np.save(str(labels_dir / "timestamps_us.npy"), result.frame_timestamps_us)
+    np.save(
+        str(repr_dir / "objframe_idx_2_repr_idx.npy"),
+        result.objframe_idx_2_repr_idx,
+    )
+    np.save(
+        str(repr_dir / "timestamps_us.npy"),
+        result.ev_repr_timestamps_us_end,
+    )
+
+
+def preprocess_sequence(
+    bbox_path: Union[str, Path],
+    out_dir: Union[str, Path],
+    *,
+    dataset: str = "gen4",
+    split: str = "val",
+    height: int = 720,
+    width: int = 1280,
+    repr_dir_name: str = RVT_REPR_DIR_NAME,
+) -> ObjframeGridResult:
+    """Read a raw bbox file, filter, align, and write the RVT artifacts.
+
+    Ties :func:`read_raw_bbox` -> :func:`apply_filters` -> the train-split faulty
+    filter gate -> :func:`build_objframes_and_grid` -> :func:`write_preprocessed`.
+    """
+    raw_labels = read_raw_bbox(bbox_path)
+    filtered = apply_filters(
+        raw_labels,
+        dataset=dataset,
+        split=split,
+        height=height,
+        width=width,
+    )
+    result = build_objframes_and_grid(filtered, dataset=dataset)
+    write_preprocessed(out_dir, result, repr_dir_name=repr_dir_name)
+    return result

--- a/python/evlib/data/label_preprocess.py
+++ b/python/evlib/data/label_preprocess.py
@@ -1,0 +1,191 @@
+"""RVT bbox filter chain for label preprocessing (build-side, task B1).
+
+Reads a raw Prophesee ``*_bbox.npy`` structured array and applies RVT's exact
+bbox filter chain, producing a filtered structured array. The arithmetic mirrors
+``lib/RVT/scripts/genx/preprocess_dataset.py`` precisely (the right/bottom crop
+bounds use ``W-1``/``H-1``) so the later byte-identical gate (B3) holds.
+
+The ``track_id`` and ``class_confidence`` fields are carried through every
+filter, matching the real on-disk schema.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+
+# Verified on-disk schema from the staged real data. The field order is
+# load-bearing: B2/B3 write ``labels.npz`` from arrays of exactly this dtype.
+BBOX_DTYPE = np.dtype(
+    [
+        ("t", "<u8"),
+        ("x", "<f4"),
+        ("y", "<f4"),
+        ("w", "<f4"),
+        ("h", "<f4"),
+        ("class_id", "u1"),
+        ("class_confidence", "<f4"),
+        ("track_id", "<u4"),
+    ]
+)
+
+LABEL_NPZ_FIELDS = tuple(BBOX_DTYPE.names)
+
+# gen1/gen4 frame geometry (RVT preprocess_dataset.py lines 58-59).
+_DATASET_HEIGHT = {"gen1": 240, "gen4": 720}
+_DATASET_WIDTH = {"gen1": 304, "gen4": 1280}
+
+
+class NoLabelsError(Exception):
+    """Raised when a sequence filters down to zero boxes.
+
+    Mirrors RVT's ``NoLabelsException`` intent: zero surviving labels is a named
+    failure, never a silently returned empty array.
+    """
+
+
+def read_raw_bbox(path: Union[str, Path]) -> np.ndarray:
+    """Load a raw structured ``*_bbox.npy`` and validate its fields.
+
+    Raises ``ValueError`` naming the path if the array is not structured with
+    exactly the expected fields. Does not coerce silently.
+    """
+    path = Path(path)
+    labels = np.load(str(path))
+    if labels.dtype.names is None:
+        raise ValueError(
+            f"{path} is not a structured bbox array (got dtype {labels.dtype})"
+        )
+    actual = tuple(labels.dtype.names)
+    if actual != LABEL_NPZ_FIELDS:
+        raise ValueError(
+            f"{path} has unexpected bbox fields {actual}; expected {LABEL_NPZ_FIELDS}"
+        )
+    return labels
+
+
+def keep_classes_gen4(labels: np.ndarray) -> np.ndarray:
+    """Keep gen4 classes pedestrian/two-wheeler/car (``class_id <= 2``).
+
+    Drops truck, bus, traffic sign, traffic light. gen4 only.
+    (RVT ``prophesee_remove_labels_filter_gen4``, lines 263-271.)
+    """
+    keep = labels["class_id"] <= 2
+    return labels[keep]
+
+
+def crop_to_fov(labels: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Clamp box edges to the FOV, recompute w/h, drop degenerate boxes.
+
+    Matches RVT ``crop_to_fov_filter`` (lines 232-260): clamp left/top/right/
+    bottom edges to ``[0, W-1]`` / ``[0, H-1]``, recompute w/h from the clamped
+    edges, then drop boxes with ``w <= 0`` or ``h <= 0``. Operates on a copy so
+    the caller's array is not mutated.
+    """
+    labels = labels.copy()
+    x_left = labels["x"]
+    y_top = labels["y"]
+    x_right = x_left + labels["w"]
+    y_bottom = y_top + labels["h"]
+
+    x_left_cropped = np.clip(x_left, a_min=0, a_max=width - 1)
+    y_top_cropped = np.clip(y_top, a_min=0, a_max=height - 1)
+    x_right_cropped = np.clip(x_right, a_min=0, a_max=width - 1)
+    y_bottom_cropped = np.clip(y_bottom, a_min=0, a_max=height - 1)
+
+    w_cropped = x_right_cropped - x_left_cropped
+    h_cropped = y_bottom_cropped - y_top_cropped
+    assert np.all(w_cropped >= 0)
+    assert np.all(h_cropped >= 0)
+
+    labels["x"] = x_left_cropped
+    labels["y"] = y_top_cropped
+    labels["w"] = w_cropped
+    labels["h"] = h_cropped
+
+    keep = (labels["w"] > 0) & (labels["h"] > 0)
+    return labels[keep]
+
+
+def conservative_size_filter(labels: np.ndarray) -> np.ndarray:
+    """Keep boxes with ``w >= 5 AND h >= 5`` (RVT ``conservative_bbox_filter``).
+
+    Used when ``apply_psee_bbox_filter`` is False (the gen4 config).
+    """
+    min_box_side = 5
+    side_ok = (labels["w"] >= min_box_side) & (labels["h"] >= min_box_side)
+    return labels[side_ok]
+
+
+def prophesee_size_filter(labels: np.ndarray, dataset: str) -> np.ndarray:
+    """Prophesee diag/side size filter (RVT ``prophesee_bbox_filter``).
+
+    Keeps boxes whose diagonal is at least ``min_box_diag`` and whose width and
+    height each reach ``min_box_side``. gen4: diag 60, side 20; gen1: 30, 10.
+    Used when ``apply_psee_bbox_filter`` is True (the gen1 branch).
+    """
+    if dataset not in {"gen1", "gen4"}:
+        raise ValueError(f"unknown dataset {dataset!r}")
+    min_box_diag = 60 if dataset == "gen4" else 30
+    min_box_side = 20 if dataset == "gen4" else 10
+
+    w_lbl = labels["w"]
+    h_lbl = labels["h"]
+    diag_ok = w_lbl**2 + h_lbl**2 >= min_box_diag**2
+    side_ok = (w_lbl >= min_box_side) & (h_lbl >= min_box_side)
+    return labels[diag_ok & side_ok]
+
+
+def remove_faulty_huge_bbox(labels: np.ndarray, width: int) -> np.ndarray:
+    """Drop boxes wider than ``(9 * width) // 10`` (RVT ``remove_faulty_huge``).
+
+    These span the frame horizontally without covering an object. TRAIN-split
+    only; the caller gates by split.
+    """
+    max_width = (9 * width) // 10
+    side_ok = labels["w"] <= max_width
+    return labels[side_ok]
+
+
+def apply_filters(
+    labels: np.ndarray,
+    *,
+    dataset: str = "gen4",
+    split: str,
+    height: int,
+    width: int,
+    apply_psee_bbox_filter: bool = False,
+    apply_faulty_bbox_filter: bool = True,
+) -> np.ndarray:
+    """Run RVT's filter chain in order, returning the surviving boxes.
+
+    Order (RVT ``apply_filters``, lines 274-288):
+    1. gen4 class removal (gen4 only),
+    2. crop-to-FOV,
+    3. size filter: prophesee diag/side if ``apply_psee_bbox_filter`` else
+       conservative (gen4 uses conservative),
+    4. faulty-huge removal, TRAIN split only and only if
+       ``apply_faulty_bbox_filter``.
+
+    Raises ``NoLabelsError`` if zero boxes survive (never returns empty silently).
+    """
+    if dataset not in {"gen1", "gen4"}:
+        raise ValueError(f"unknown dataset {dataset!r}")
+
+    if dataset == "gen4":
+        labels = keep_classes_gen4(labels)
+    labels = crop_to_fov(labels, height, width)
+    if apply_psee_bbox_filter:
+        labels = prophesee_size_filter(labels, dataset)
+    else:
+        labels = conservative_size_filter(labels)
+    if split == "train" and apply_faulty_bbox_filter:
+        labels = remove_faulty_huge_bbox(labels, width)
+
+    if labels.shape[0] == 0:
+        raise NoLabelsError(
+            f"all boxes removed by the filter chain (dataset={dataset}, split={split})"
+        )
+    return labels

--- a/python/evlib/data/ncaltech.py
+++ b/python/evlib/data/ncaltech.py
@@ -1,0 +1,64 @@
+"""Reader for the N-Caltech101 ATIS ``.bin`` event format.
+
+N-Caltech101 recordings are the standard ATIS binary event stream: 5 bytes
+per event, sensor 240 (width) x 180 (height). Each 5-byte group
+``(b0, b1, b2, b3, b4)`` decodes as::
+
+    x = b0
+    y = b1
+    polarity = b2 >> 7
+    t_us = ((b2 & 0x7F) << 16) | (b3 << 8) | b4
+
+with the timestamp in microseconds (a 23-bit value spread across the low 7
+bits of ``b2`` and all of ``b3`` and ``b4``).
+"""
+
+from os import PathLike
+
+import numpy as np
+import polars as pl
+
+NCALTECH_HEIGHT = 180
+NCALTECH_WIDTH = 240
+
+_BYTES_PER_EVENT = 5
+
+
+def read_atis_bin(path: str | PathLike) -> pl.DataFrame:
+    """Decode an N-Caltech101 ATIS ``.bin`` file into an event frame.
+
+    Returns a Polars DataFrame with columns ``x``, ``y``, ``t``, ``polarity``
+    (all ``Int64``), in file order. ``t`` is the event timestamp in
+    microseconds. ``polarity`` is the raw ATIS polarity bit (0 or 1).
+
+    Raises ``ValueError`` if the file length is not a multiple of 5 bytes.
+    """
+    raw = np.fromfile(path, dtype=np.uint8)
+    if raw.size % _BYTES_PER_EVENT != 0:
+        raise ValueError(
+            f"ATIS .bin file length {raw.size} is not a multiple of "
+            f"{_BYTES_PER_EVENT} bytes: {path}"
+        )
+
+    events = raw.reshape(-1, _BYTES_PER_EVENT).astype(np.int64)
+    b0, b1, b2, b3, b4 = (events[:, i] for i in range(_BYTES_PER_EVENT))
+
+    x = b0
+    y = b1
+    polarity = b2 >> 7
+    t_us = ((b2 & 0x7F) << 16) | (b3 << 8) | b4
+
+    return pl.DataFrame(
+        {
+            "x": x,
+            "y": y,
+            "t": t_us,
+            "polarity": polarity,
+        },
+        schema={
+            "x": pl.Int64,
+            "y": pl.Int64,
+            "t": pl.Int64,
+            "polarity": pl.Int64,
+        },
+    )

--- a/python/evlib/data/ncaltech.py
+++ b/python/evlib/data/ncaltech.py
@@ -14,9 +14,13 @@ bits of ``b2`` and all of ``b3`` and ``b4``).
 """
 
 from os import PathLike
+from pathlib import Path
 
 import numpy as np
 import polars as pl
+
+from evlib.rvt.representation import build_sparse_histogram
+from evlib.rvt.writer import scatter_window_dense
 
 NCALTECH_HEIGHT = 180
 NCALTECH_WIDTH = 240
@@ -62,3 +66,100 @@ def read_atis_bin(path: str | PathLike) -> pl.DataFrame:
             "polarity": pl.Int64,
         },
     )
+
+
+def representation_from_events(
+    events: pl.DataFrame,
+    *,
+    nbins: int = 10,
+    count_cutoff: int = 10,
+    height: int = NCALTECH_HEIGHT,
+    width: int = NCALTECH_WIDTH,
+) -> np.ndarray:
+    """Build one full-recording stacked-histogram representation.
+
+    Each N-Caltech recording maps to a single classification sample: one
+    stacked-histogram window spanning the whole recording. The window end is
+    ``T = t_max`` with ``delta_t_us = t_max - t_min`` so the membership rule
+    ``T - delta_t <= t <= T`` (read from
+    :func:`evlib.rvt.representation.build_sparse_histogram`) admits every event
+    in ``[t_min, t_max]`` inclusive. For a degenerate single-timestamp
+    recording (``t_max == t_min``) a ``delta_t_us`` of 1 keeps the lone event
+    in range without dividing by a zero span (the backend already clamps the
+    binning denominator to >= 1, so the event lands in temporal bin 0).
+
+    Returns a dense ``[2 * nbins, height, width]`` ``uint8`` array. Channels
+    are polarity-major: ``channel = polarity * nbins + temporal_bin``.
+    """
+    if events.height == 0:
+        raise ValueError("cannot build a representation from an empty event frame")
+
+    backend_events = events.rename({"polarity": "p"})
+
+    t_min = int(backend_events["t"].min())
+    t_max = int(backend_events["t"].max())
+    delta_t_us = max(t_max - t_min, 1)
+
+    sparse = build_sparse_histogram(
+        backend_events,
+        ev_repr_timestamps_us=np.array([t_max], dtype=np.int64),
+        delta_t_us=delta_t_us,
+        nbins=nbins,
+        count_cutoff=count_cutoff,
+        height=height,
+        width=width,
+        downsample_by_2=False,
+    )
+    window = sparse.filter(pl.col("window_id") == 0)
+    return scatter_window_dense(window, channels=2 * nbins, height=height, width=width)
+
+
+def convert_ncaltech(
+    root_dir: str | PathLike,
+    out_dir: str | PathLike,
+    *,
+    nbins: int = 10,
+    count_cutoff: int = 10,
+) -> tuple[list[Path], list[int]]:
+    """Convert an N-Caltech101 class tree into ``SampleDataset`` inputs.
+
+    Walks ``root_dir/<class_name>/*.bin``, builds the class->int label map as
+    ``sorted(class_dir_names)`` mapped to ``0..K-1``, decodes each recording
+    via :func:`read_atis_bin`, builds its full-recording representation, and
+    writes ``<out_dir>/<idx>.npy`` (uint8) per recording plus a parallel
+    ``<out_dir>/labels.npy`` (int64). Returns the per-sample paths and labels.
+
+    Raises ``ValueError`` if ``root_dir`` has no class subdirectories or a
+    class subdirectory contains no ``.bin`` files.
+    """
+    root = Path(root_dir)
+    out = Path(out_dir)
+
+    class_dirs = sorted(entry for entry in root.iterdir() if entry.is_dir())
+    if not class_dirs:
+        raise ValueError(f"no class subdirectories found under {root}")
+
+    out.mkdir(parents=True, exist_ok=True)
+
+    sample_paths: list[Path] = []
+    labels: list[int] = []
+    sample_index = 0
+    for label, class_dir in enumerate(class_dirs):
+        bin_files = sorted(class_dir.glob("*.bin"))
+        if not bin_files:
+            raise ValueError(
+                f"class directory {class_dir.name!r} contains no .bin files"
+            )
+        for bin_file in bin_files:
+            events = read_atis_bin(bin_file)
+            rep = representation_from_events(
+                events, nbins=nbins, count_cutoff=count_cutoff
+            )
+            sample_path = out / f"{sample_index}.npy"
+            np.save(sample_path, rep)
+            sample_paths.append(sample_path)
+            labels.append(label)
+            sample_index += 1
+
+    np.save(out / "labels.npy", np.array(labels, dtype=np.int64))
+    return sample_paths, labels

--- a/python/evlib/data/sources.py
+++ b/python/evlib/data/sources.py
@@ -292,11 +292,14 @@ class EvlibStreamSource:
 
     def read_windows(self, lo: int, hi: int):
         self._ensure_grid()
-        self._ensure_time()
+        # Validate the requested range against the cheap grid BEFORE the heavy
+        # _ensure_time() global-time build (~2 GB on real data), so an out-of-
+        # bounds call raises without triggering the full read.
         if lo < 0 or hi > len(self._grid) or lo >= hi:
             raise ValueError(
                 f"window range [{lo},{hi}) out of bounds for {len(self._grid)} windows"
             )
+        self._ensure_time()
 
         out_h, out_w = (
             (self.height // 2, self.width // 2)

--- a/python/evlib/data/sources.py
+++ b/python/evlib/data/sources.py
@@ -228,11 +228,63 @@ class EvlibStreamSource:
         # The window-end grid is the same one process_sequence wrote next to the
         # representation h5; loaded lazily so construction is cheap and picklable.
         self._grid = None
+        # The corrected global time array and its derived window-start/-end index
+        # arrays are built once per worker (see _ensure_time) and never pickled:
+        # _t_full is ~2 GB on a real gen4 sequence, so re-reading and re-correcting
+        # it on every read_windows call is impractical in a training loop, and
+        # carrying it through pickle would break fork/spawn DataLoader workers.
+        self._t_full = None
+        self._starts = None
+        self._ends = None
 
     def _ensure_grid(self) -> None:
         if self._grid is None:
             grid_path = self.label_source._repr_dir / "timestamps_us.npy"
             self._grid = np.load(grid_path).astype(np.int64)
+
+    def _ensure_time(self) -> None:
+        """Build and cache the corrected global time and window index arrays.
+
+        Reads the whole raw uint32 time column once, corrects it to non-decreasing
+        in place (exactly as ``_process_sequence_rust`` does), then searchsorts the
+        window-start/-end indices over the grid. All three arrays are cached so
+        subsequent ``read_windows`` calls reuse them rather than re-reading ~2 GB.
+        Requires ``_ensure_grid`` to have run, as the index arrays need the grid.
+        """
+        if self._t_full is not None:
+            return
+        self._ensure_grid()
+        h5py = _import_h5()
+        with h5py.File(str(self.raw_h5), "r") as f:
+            t_ds = f[self.dataset_group]["t"]
+            n_total = t_ds.shape[0]
+            t_full = np.empty(n_total, dtype=np.uint32)
+            chunk = 16_000_000
+            for c0 in range(0, n_total, chunk):
+                c1 = min(c0 + chunk, n_total)
+                t_full[c0:c1] = t_ds[c0:c1]
+        np.maximum.accumulate(t_full, out=t_full)
+        self._t_full = t_full
+        self._starts = np.searchsorted(
+            t_full, self._grid - self.delta_t_us, side="left"
+        )
+        self._ends = np.searchsorted(t_full, self._grid, side="right")
+
+    def __getstate__(self) -> dict:
+        # Drop the large corrected-time array and its derived index arrays so the
+        # source pickles cheaply; each spawned/forked worker rebuilds its own via
+        # _ensure_time. label_source and the small _grid carry through intact.
+        state = self.__dict__.copy()
+        state["_t_full"] = None
+        state["_starts"] = None
+        state["_ends"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._t_full = None
+        self._starts = None
+        self._ends = None
 
     def window_count(self) -> int:
         self._ensure_grid()
@@ -240,6 +292,7 @@ class EvlibStreamSource:
 
     def read_windows(self, lo: int, hi: int):
         self._ensure_grid()
+        self._ensure_time()
         if lo < 0 or hi > len(self._grid) or lo >= hi:
             raise ValueError(
                 f"window range [{lo},{hi}) out of bounds for {len(self._grid)} windows"
@@ -260,37 +313,26 @@ class EvlibStreamSource:
         h5py = _import_h5()
 
         grid = self._grid
+        # starts/ends/_t_full are built once by _ensure_time and reused here.
+        ev_lo = int(self._starts[lo])
+        ev_hi = int(self._ends[hi - 1])
+        n_windows = hi - lo
+        if ev_hi <= ev_lo:
+            # No events cover any requested window; emit empty dense windows.
+            channels = 2 * self.nbins
+            ev = [
+                torch.zeros((channels, out_h, out_w), dtype=torch.uint8)
+                for _ in range(n_windows)
+            ]
+            _, labels = self.label_source.read_windows(lo, hi)
+            return ev, labels
+
+        t_batch = np.asarray(self._t_full[ev_lo:ev_hi], dtype=np.int64)
+        coord_dt = np.int32 if self.gpu else np.int64
         with h5py.File(str(self.raw_h5), "r") as f:
             grp = f[self.dataset_group]
-            # Read the whole raw uint32 time column and correct it to non-decreasing
-            # in place, exactly as _process_sequence_rust does, so the searchsorted
-            # window slices run over the same global corrected time array.
-            t_ds = grp["t"]
-            n_total = t_ds.shape[0]
-            t_full = np.empty(n_total, dtype=np.uint32)
-            chunk = 16_000_000
-            for c0 in range(0, n_total, chunk):
-                c1 = min(c0 + chunk, n_total)
-                t_full[c0:c1] = t_ds[c0:c1]
-            np.maximum.accumulate(t_full, out=t_full)
-            starts = np.searchsorted(t_full, grid - self.delta_t_us, side="left")
-            ends = np.searchsorted(t_full, grid, side="right")
-
-            ev_lo = int(starts[lo])
-            ev_hi = int(ends[hi - 1])
-            n_windows = hi - lo
-            if ev_hi <= ev_lo:
-                # No events cover any requested window; emit empty dense windows.
-                channels = 2 * self.nbins
-                ev = [
-                    torch.zeros((channels, out_h, out_w), dtype=torch.uint8)
-                    for _ in range(n_windows)
-                ]
-                _, labels = self.label_source.read_windows(lo, hi)
-                return ev, labels
-
-            t_batch = np.asarray(t_full[ev_lo:ev_hi], dtype=np.int64)
-            coord_dt = np.int32 if self.gpu else np.int64
+            # Only the small per-batch x/y/p slices are read per call (cheap); the
+            # global corrected time is already cached in self._t_full.
             x_batch = np.asarray(grp["x"][ev_lo:ev_hi], dtype=coord_dt)
             y_batch = np.asarray(grp["y"][ev_lo:ev_hi], dtype=coord_dt)
             p_batch = np.asarray(grp["p"][ev_lo:ev_hi], dtype=coord_dt)

--- a/python/evlib/pytorch.py
+++ b/python/evlib/pytorch.py
@@ -1,8 +1,0 @@
-"""PyTorch integration for evlib.
-
-The legacy ``PolarsDataset`` and its associated loader/transform helpers have
-been retired. PyTorch data loading for event-vision training now lives in the
-``evlib.data`` package.
-"""
-
-__all__: list[str] = []

--- a/tests/test_data_augment.py
+++ b/tests/test_data_augment.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 import numpy as np
 import torch
 
-from evlib.data.augment import SequenceAugmentor
+from evlib.data.augment import (
+    SequenceAugmentor,
+    _AugmentationState,
+    _ZoomOutState,
+)
 from evlib.data.sequence import SequenceSample
 
 
@@ -198,9 +202,114 @@ def test_zoom_out_factor2_tensor_and_box_exact():
     assert torch.allclose(out.labels[0], expected_box)
 
 
+def test_zoom_out_forced_params_hand_pinned_box():
+    # FORCE the zoom-out state directly (no RNG discovery): factor 2 with the
+    # shrunk canvas pasted at the KNOWN offset (x0=1, y0=1). Both the tensor and
+    # the box are pinned to independently hand-computed coordinates.
+    window = _arange_window()
+    # top-left box (x=0, y=0, w=2, h=2) -> centre (1.0, 1.0, 2, 2)
+    box = _centre_box(5.0, 1.0, 1.0, 2.0, 2.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=0.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    state = _AugmentationState(
+        apply_h_flip=False,
+        rotation_active=False,
+        rotation_angle_deg=0.0,
+        apply_zoom_in=False,
+        zoom_in_factor=1.0,
+        zoom_out=_ZoomOutState(active=True, x0=1, y0=1, factor=2.0),
+    )
+    out = aug._apply(sample, state, (4, 4))
+
+    # Tensor: shrink 4x4 -> 2x2 nearest-exact, paste at the FORCED (x0=1, y0=1).
+    from torch.nn.functional import interpolate
+
+    shrunk = interpolate(
+        window.unsqueeze(0).float(), size=(2, 2), mode="nearest-exact"
+    )[0].to(torch.uint8)
+    expected_tensor = torch.zeros_like(window)
+    expected_tensor[:, 1:3, 1:3] = shrunk
+    assert torch.equal(out.ev_repr[0], expected_tensor)
+
+    # Box per RVT zoom_out: scale(1/2) of top-left (0,0,2,2) with clamp to
+    # new_img-1 = 1 gives (0, 0, 1, 1); translate by (x0=1, y0=1) -> (1, 1, 1, 1).
+    # centre cx = 1 + 0.5 = 1.5, cy = 1.5, w = 1, h = 1.
+    expected_box = _centre_box(5.0, 1.5, 1.5, 1.0, 1.0)
+    assert torch.allclose(out.labels[0], expected_box)
+
+
 # ---------------------------------------------------------------------------
 # Zoom in
 # ---------------------------------------------------------------------------
+
+
+def test_zoom_in_forced_params_hand_pinned_box():
+    # FORCE zoom-in factor 2 and a box geometry whose label-aware valid window
+    # COLLAPSES to a single point (x0_valid == x1_valid == 2), so _uniform(2, 2)
+    # returns 2 deterministically: the crop offset is (2, 2) with no RNG draw.
+    window = torch.arange(64, dtype=torch.uint8).reshape(8, 8)
+    window = torch.stack([window, window], dim=0)
+    # top-left box (x=2, y=2, w=4, h=4) -> centre (4.0, 4.0, 4, 4).
+    box = _centre_box(1.0, 4.0, 4.0, 4.0, 4.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=0.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    state = _AugmentationState(
+        apply_h_flip=False,
+        rotation_active=False,
+        rotation_angle_deg=0.0,
+        apply_zoom_in=True,
+        zoom_in_factor=2.0,
+        zoom_out=_ZoomOutState(active=False, x0=0, y0=0, factor=1.0),
+    )
+    out = aug._apply(sample, state, (8, 8))
+
+    # Tensor: crop window[2:6, 2:6] (4x4) upscaled to 8x8 nearest-exact, with the
+    # FORCED crop offset (x0=2, y0=2).
+    from torch.nn.functional import interpolate
+
+    crop = window[:, 2:6, 2:6].unsqueeze(0).float()
+    expected_tensor = interpolate(crop, size=(8, 8), mode="nearest-exact")[0].to(
+        torch.uint8
+    )
+    assert torch.equal(out.ev_repr[0], expected_tensor)
+
+    # Box per RVT zoom_in: clamp into the crop -> (new_x=0, new_y=0, new_w=3,
+    # new_h=3) after subtracting (z_x0=2, z_y0=2) and clamping x1,y1 to z*1-1=5;
+    # then scale_ by factor 2 with clamp to new_img-1=7 -> (0, 0, 6, 6).
+    # centre cx = 0 + 3 = 3.0, cy = 3.0, w = 6, h = 6.
+    expected_box = _centre_box(1.0, 3.0, 3.0, 6.0, 6.0)
+    assert torch.allclose(out.labels[0], expected_box)
+
+
+def test_zoom_in_factor_exactly_one_is_noop():
+    # A zoom-in factor of exactly 1.0 is a documented no-op: _apply short-circuits
+    # on `state.zoom_in_factor != 1.0`, matching RVT's behaviour, so the tensor
+    # and boxes pass through unchanged.
+    window = _arange_window()
+    box = _centre_box(2.0, 1.5, 1.5, 1.0, 1.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=0.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    state = _AugmentationState(
+        apply_h_flip=False,
+        rotation_active=False,
+        rotation_angle_deg=0.0,
+        apply_zoom_in=True,
+        zoom_in_factor=1.0,
+        zoom_out=_ZoomOutState(active=False, x0=0, y0=0, factor=1.0),
+    )
+    out = aug._apply(sample, state, (4, 4))
+
+    assert torch.equal(out.ev_repr[0], window)
+    assert torch.allclose(out.labels[0], box)
 
 
 def test_zoom_in_factor2_label_aware_tensor_and_box_exact():

--- a/tests/test_data_augment.py
+++ b/tests/test_data_augment.py
@@ -1,0 +1,354 @@
+"""Deterministic per-transform tests for the bbox-aware SequenceAugmentor.
+
+These hand-computed tests are the primary correctness evidence for Task C-core
+(the slow RVT bit-equivalence gate is a separate later task that may skip when
+RVT deps are absent). Each transform is checked on a tiny [2, 4, 4] window with
+one or two known boxes so BOTH the tensor and the box land at exact coordinates
+that are verified against the vendored RVT math
+(lib/RVT/data/utils/augmentor.py + lib/RVT/data/genx_utils/labels.py).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from evlib.data.augment import SequenceAugmentor
+from evlib.data.sequence import SequenceSample
+
+
+def _arange_window(channels: int = 2, height: int = 4, width: int = 4) -> torch.Tensor:
+    """A deterministic uint8 window whose values double on the second channel."""
+    base = torch.arange(height * width, dtype=torch.int64).reshape(height, width)
+    second = (base * 2) % 256
+    return torch.stack([base, second], dim=0).to(torch.uint8)
+
+
+def _centre_box(class_id, cx, cy, w, h) -> torch.Tensor:
+    return torch.tensor([[class_id, cx, cy, w, h]], dtype=torch.float32)
+
+
+def _sample(ev_repr, labels, is_padded_mask=None, is_first_sample=True):
+    if is_padded_mask is None:
+        is_padded_mask = [False] * len(ev_repr)
+    return SequenceSample(
+        ev_repr=ev_repr,
+        labels=labels,
+        is_first_sample=is_first_sample,
+        is_padded_mask=is_padded_mask,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Horizontal flip
+# ---------------------------------------------------------------------------
+
+
+def test_hflip_tensor_and_box_exact():
+    window = _arange_window()
+    # top-left box (x=1, y=1, w=1, h=1) -> centre (cx=1.5, cy=1.5, w=1, h=1)
+    box = _centre_box(0.0, 1.5, 1.5, 1.0, 1.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=1.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    out = aug(sample)
+
+    expected_tensor = torch.flip(window, dims=[-1])
+    assert torch.equal(out.ev_repr[0], expected_tensor)
+    assert out.ev_repr[0].dtype == torch.uint8
+
+    # RVT flip_lr_: x_new = W - 1 - x - w = 3 - 1 - 1 = 1 (top-left), so
+    # centre cx = 1 + 0.5 = 1.5; y, w, h unchanged.
+    expected_box = _centre_box(0.0, 1.5, 1.5, 1.0, 1.0)
+    assert torch.allclose(out.labels[0], expected_box)
+
+
+def test_hflip_box_moves_for_offcentre_box():
+    window = _arange_window()
+    # top-left box (x=0, y=0, w=2, h=2) -> centre (1.0, 1.0, 2, 2)
+    box = _centre_box(3.0, 1.0, 1.0, 2.0, 2.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=1.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    out = aug(sample)
+
+    # x_new = 3 - 0 - 2 = 1 (top-left) -> centre cx = 1 + 1 = 2.0
+    expected_box = _centre_box(3.0, 2.0, 1.0, 2.0, 2.0)
+    assert torch.allclose(out.labels[0], expected_box)
+
+
+# ---------------------------------------------------------------------------
+# Rotate
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_90deg_tensor_and_box_exact():
+    window = _arange_window()
+    # top-left box (x=1, y=1, w=1, h=1) -> centre (1.5, 1.5, 1, 1)
+    box = _centre_box(0.0, 1.5, 1.5, 1.0, 1.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=0.0,
+        rotate_prob=1.0,
+        rotate_min_deg=90.0,
+        rotate_max_deg=90.0,
+        zoom_prob=0.0,
+        # seed 2 draws a positive sign so the rotation is +90 deg (CCW).
+        rng=np.random.default_rng(2),
+    )
+    out = aug(sample)
+
+    from torchvision.transforms import InterpolationMode
+    from torchvision.transforms.functional import rotate as tv_rotate
+
+    expected_tensor = tv_rotate(window, 90.0, interpolation=InterpolationMode.NEAREST)
+    assert torch.equal(out.ev_repr[0], expected_tensor)
+
+    # Hand-computed: corners of top-left box rotated CCW 90deg about (2, 2)
+    # give axis-aligned bbox top-left (x0=1, y0=2, w=1, h=1) -> centre (1.5, 2.5).
+    expected_box = _centre_box(0.0, 1.5, 2.5, 1.0, 1.0)
+    assert torch.allclose(out.labels[0], expected_box)
+
+
+def test_rotate_uses_random_sign():
+    # rotate_min == rotate_max (=90) so the only randomness is the sign. A 90deg
+    # rotation moves the box to distinguishable centres: +90 -> (1.5, 2.5),
+    # -90 -> (2.5, 1.5). Across seeds we must see BOTH signs, proving the random
+    # sign is exercised. (A 4deg NEAREST rotation is too small to move a tiny
+    # tensor, so we assert via the box coordinate, not the tensor.)
+    window = _arange_window()
+    box = _centre_box(0.0, 1.5, 1.5, 1.0, 1.0)
+
+    pos_centre = _centre_box(0.0, 1.5, 2.5, 1.0, 1.0)
+    neg_centre = _centre_box(0.0, 2.5, 1.5, 1.0, 1.0)
+
+    seen = set()
+    for seed in range(20):
+        aug = SequenceAugmentor(
+            prob_hflip=0.0,
+            rotate_prob=1.0,
+            rotate_min_deg=90.0,
+            rotate_max_deg=90.0,
+            zoom_prob=0.0,
+            rng=np.random.default_rng(seed),
+        )
+        out = aug(_sample([window.clone()], [box.clone()]))
+        if torch.allclose(out.labels[0], pos_centre):
+            seen.add("pos")
+        elif torch.allclose(out.labels[0], neg_centre):
+            seen.add("neg")
+        else:
+            raise AssertionError(f"rotate produced unexpected box {out.labels[0]}")
+    assert seen == {"pos", "neg"}
+
+
+# ---------------------------------------------------------------------------
+# Zoom out
+# ---------------------------------------------------------------------------
+
+
+def test_zoom_out_factor2_tensor_and_box_exact():
+    window = _arange_window()
+    # top-left box (x=0, y=0, w=2, h=2) -> centre (1.0, 1.0, 2, 2)
+    box = _centre_box(5.0, 1.0, 1.0, 2.0, 2.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    # Force a zoom-out at factor 2 with placement at (x0=0, y0=0).
+    aug = SequenceAugmentor(
+        prob_hflip=0.0,
+        rotate_prob=0.0,
+        zoom_prob=1.0,
+        zoom_in_weight=0,
+        zoom_out_weight=1,
+        zoom_out_range=(2.0, 2.0),
+        rng=np.random.default_rng(0),
+    )
+    out = aug(sample)
+
+    # Tensor: shrink 4x4 -> 2x2 via nearest-exact, paste at sampled (x0, y0).
+    # The placement offset is RNG-sampled in [0, W - 2]; discover it from the
+    # tensor, then assert both tensor and box agree on the same offset.
+    from torch.nn.functional import interpolate
+
+    shrunk = interpolate(
+        window.unsqueeze(0).float(), size=(2, 2), mode="nearest-exact"
+    )[0].to(torch.uint8)
+
+    found = None
+    for y0 in range(0, 4 - 2 + 1):
+        for x0 in range(0, 4 - 2 + 1):
+            canvas = torch.zeros_like(window)
+            canvas[:, y0 : y0 + 2, x0 : x0 + 2] = shrunk
+            if torch.equal(out.ev_repr[0], canvas):
+                found = (x0, y0)
+                break
+        if found is not None:
+            break
+    assert found is not None, "zoom-out tensor did not match any valid offset"
+    x0, y0 = found
+
+    # Box per RVT zoom_out: scale(1/2) -> top-left (0, 0, 1, 1); +(x0, y0).
+    # centre cx = x0 + 0.5, cy = y0 + 0.5, w = 1, h = 1.
+    expected_box = _centre_box(5.0, x0 + 0.5, y0 + 0.5, 1.0, 1.0)
+    assert torch.allclose(out.labels[0], expected_box)
+
+
+# ---------------------------------------------------------------------------
+# Zoom in
+# ---------------------------------------------------------------------------
+
+
+def test_zoom_in_factor2_label_aware_tensor_and_box_exact():
+    # Use an 8x8 window so a factor-2 zoom-in crop (4x4) can fully contain a
+    # box and the label-aware window sampling has a deterministic solution.
+    window = torch.arange(64, dtype=torch.uint8).reshape(8, 8)
+    window = torch.stack([window, window], dim=0)
+    # top-left box (x=2, y=2, w=2, h=2) -> centre (3.0, 3.0, 2, 2)
+    box = _centre_box(1.0, 3.0, 3.0, 2.0, 2.0)
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=0.0,
+        rotate_prob=0.0,
+        zoom_prob=1.0,
+        zoom_in_weight=1,
+        zoom_out_weight=0,
+        zoom_in_range=(2.0, 2.0),
+        rng=np.random.default_rng(0),
+    )
+    out = aug(sample)
+
+    # crop window is 4x4. label-aware sampling must keep box (x1=4 <= crop)
+    # fully inside. With this seed we capture the realised (x0, y0) from the
+    # tensor and assert the box matches the same crop deterministically.
+    from torch.nn.functional import interpolate
+
+    # Discover the realised crop offset by matching against all valid offsets.
+    realised = out.ev_repr[0]
+    found = None
+    for y0 in range(0, 8 - 4 + 1):
+        for x0 in range(0, 8 - 4 + 1):
+            crop = window[:, y0 : y0 + 4, x0 : x0 + 4].unsqueeze(0).float()
+            up = interpolate(crop, size=(8, 8), mode="nearest-exact")[0].to(torch.uint8)
+            if torch.equal(up, realised):
+                found = (x0, y0)
+                break
+        if found is not None:
+            break
+    assert found is not None, "zoom-in tensor did not match any valid crop"
+    x0, y0 = found
+
+    # The crop must fully contain the box [2,4]x[2,4]; label-aware sampling
+    # guarantees x0 <= 2 and x0 + 4 >= 4 (=> 0 <= x0 <= 2), same for y0.
+    assert 0 <= x0 <= 2
+    assert 0 <= y0 <= 2
+
+    # Box per RVT zoom_in_and_rescale_: subtract (x0, y0), scale by factor 2.
+    bx = (2 - x0) * 2.0
+    by = (2 - y0) * 2.0
+    bw = 2 * 2.0  # 4
+    bh = 2 * 2.0
+    expected_centre = torch.tensor(
+        [[1.0, bx + bw / 2.0, by + bh / 2.0, bw, bh]], dtype=torch.float32
+    )
+    assert torch.allclose(out.labels[0], expected_centre)
+
+
+# ---------------------------------------------------------------------------
+# Sequence-wide consistency, padding, None labels, dropped boxes
+# ---------------------------------------------------------------------------
+
+
+def test_params_drawn_once_per_call():
+    windows = [_arange_window().clone() for _ in range(3)]
+    boxes = [_centre_box(0.0, 1.5, 1.5, 1.0, 1.0) for _ in range(3)]
+    sample = _sample(windows, boxes)
+
+    aug = SequenceAugmentor(
+        prob_hflip=1.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    out = aug(sample)
+
+    expected = torch.flip(_arange_window(), dims=[-1])
+    for window in out.ev_repr:
+        assert torch.equal(window, expected)
+    for box in out.labels:
+        assert torch.allclose(box, _centre_box(0.0, 1.5, 1.5, 1.0, 1.0))
+
+
+def test_padded_windows_untouched():
+    real = _arange_window()
+    padded = torch.zeros(2, 4, 4, dtype=torch.uint8)
+    box = _centre_box(0.0, 1.5, 1.5, 1.0, 1.0)
+    sample = _sample(
+        [real.clone(), padded.clone()],
+        [box.clone(), None],
+        is_padded_mask=[False, True],
+    )
+
+    aug = SequenceAugmentor(
+        prob_hflip=1.0, rotate_prob=0.0, zoom_prob=0.0, rng=np.random.default_rng(0)
+    )
+    out = aug(sample)
+
+    # Padded slot unchanged, its label stays None.
+    assert torch.equal(out.ev_repr[1], padded)
+    assert out.labels[1] is None
+    # Real slot was flipped.
+    assert torch.equal(out.ev_repr[0], torch.flip(real, dims=[-1]))
+
+
+def test_none_labels_survive_each_transform():
+    window = _arange_window()
+    sample = _sample([window.clone()], [None])
+
+    aug = SequenceAugmentor(
+        prob_hflip=1.0,
+        rotate_prob=1.0,
+        rotate_min_deg=90.0,
+        rotate_max_deg=90.0,
+        zoom_prob=0.0,
+        rng=np.random.default_rng(0),
+    )
+    out = aug(sample)
+
+    assert out.labels[0] is None
+    # tensor was still transformed.
+    assert not torch.equal(out.ev_repr[0], window)
+
+
+def test_box_pushed_out_of_frame_is_dropped():
+    window = _arange_window()
+    # A degenerate-after-flip box at the far right edge that flip pushes to the
+    # left edge but then a 90deg rotation collapses. Instead test a box that
+    # rotation maps to a degenerate (w<=0) bbox after clamping: place a thin box
+    # on the boundary. Use a box at the very corner that clamps to zero area.
+    box = _centre_box(0.0, 3.0, 3.0, 0.5, 0.5)  # top-left (2.75, 2.75) w=h=0.5
+    sample = _sample([window.clone()], [box.clone()])
+
+    aug = SequenceAugmentor(
+        prob_hflip=0.0,
+        rotate_prob=0.0,
+        zoom_prob=1.0,
+        zoom_in_weight=0,
+        zoom_out_weight=1,
+        zoom_out_range=(4.0, 4.0),  # shrink to 1x1, scale boxes by 1/4
+        rng=np.random.default_rng(0),
+    )
+    out = aug(sample)
+
+    # After scaling by 1/4 the 0.5-wide box becomes 0.125 wide and clamps to a
+    # degenerate (w<=0 after RVT clamp logic) box, which RVT drops -> None.
+    assert out.labels[0] is None
+
+
+def test_sequence_augmentor_exported_from_package():
+    import evlib.data as data
+
+    assert data.SequenceAugmentor is SequenceAugmentor
+    assert "SequenceAugmentor" in data.__all__

--- a/tests/test_data_augment_rvt_equiv.py
+++ b/tests/test_data_augment_rvt_equiv.py
@@ -1,0 +1,173 @@
+"""Slow RVT bit-equivalence gate for the bbox-aware SequenceAugmentor.
+
+evlib's ``SequenceAugmentor`` uses a numpy RNG; RVT's
+``RandomSpatialAugmentorGenX`` uses a torch RNG. The two RNG streams are NOT
+bit-identical, so a shared seed cannot prove equivalence. Instead this test
+FORCES identical augmentation params (flip flag, rotation angle, zoom
+direction/factor and zoom offsets) into BOTH implementations and asserts their
+outputs match: the augmented ``[C, H, W]`` uint8 tensor is byte-identical
+(``np.array_equal``) and the transformed yolox boxes agree, after converting
+RVT's top-left-stored ``ObjectLabels`` to the yolox CENTRE form evlib produces.
+
+The reference math is the vendored RVT source itself, not a re-implementation:
+``lib/RVT/data/utils/augmentor.py`` (tensor ops) and
+``lib/RVT/data/genx_utils/labels.py`` (``ObjectLabels`` box ops). It is run as a
+LOCAL-ONLY slow gate; on machines where RVT or its deps (einops/omegaconf) are
+not importable the whole module skips cleanly via ``importorskip`` rather than
+weakening into a non-equivalence check.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = pytest.mark.slow
+
+# The vendored RVT tree is imported as a top-level package rooted at lib/RVT, so
+# its internal ``from data...`` / ``from utils...`` imports resolve. Inserted
+# before importorskip so the guarded imports below see it on sys.path.
+_RVT_ROOT = Path(__file__).resolve().parent.parent / "lib" / "RVT"
+if _RVT_ROOT.is_dir() and str(_RVT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RVT_ROOT))
+
+# RVT's labels module imports einops at top level; the augmentor imports
+# omegaconf. Skip the whole gate cleanly if either (or the RVT tree) is absent.
+pytest.importorskip("einops", reason="RVT labels require einops")
+pytest.importorskip("omegaconf", reason="RVT augmentor requires omegaconf")
+rvt_labels = pytest.importorskip(
+    "data.genx_utils.labels", reason="vendored RVT tree not importable"
+)
+rvt_augmentor = pytest.importorskip(
+    "data.utils.augmentor", reason="vendored RVT tree not importable"
+)
+rvt_types = pytest.importorskip(
+    "data.utils.types", reason="vendored RVT tree not importable"
+)
+
+from evlib.data.augment import SequenceAugmentor  # noqa: E402
+
+ObjectLabels = rvt_labels.ObjectLabels
+RandomSpatialAugmentorGenX = rvt_augmentor.RandomSpatialAugmentorGenX
+DataType = rvt_types.DataType
+
+HEIGHT = WIDTH = 8
+
+
+def _window() -> torch.Tensor:
+    """A deterministic [2, 8, 8] uint8 window; channel 1 is channel 0 doubled."""
+    base = torch.arange(HEIGHT * WIDTH, dtype=torch.int64).reshape(HEIGHT, WIDTH)
+    return torch.stack([base, (base * 2) % 256], dim=0).to(torch.uint8)
+
+
+def _evlib_centre_box() -> torch.Tensor:
+    """One box, evlib yolox CENTRE form [class_id, cx, cy, w, h].
+
+    Top-left rectangle (x=2, y=2, w=2, h=2) -> centre (cx=3, cy=3, w=2, h=2).
+    """
+    return torch.tensor([[0.0, 3.0, 3.0, 2.0, 2.0]], dtype=torch.float32)
+
+
+def _rvt_object_labels() -> "ObjectLabels":
+    """The SAME box as RVT 7-field rows [t, x, y, w, h, class_id, class_conf].
+
+    RVT stores TOP-LEFT (x=2, y=2); ``get_labels_as_tensors('yolox')`` converts
+    to the centre form evlib produces, so the two are directly comparable.
+    """
+    rows = torch.tensor([[0.0, 2.0, 2.0, 2.0, 2.0, 0.0, 1.0]], dtype=torch.float32)
+    return ObjectLabels(object_labels=rows, input_size_hw=(HEIGHT, WIDTH))
+
+
+def _aug() -> SequenceAugmentor:
+    # The RNG is irrelevant here: every test calls the per-transform static
+    # methods with explicitly forced params, so no sampling happens.
+    return SequenceAugmentor(rng=np.random.default_rng(0))
+
+
+def test_hflip_bit_equivalent_to_rvt():
+    aug = _aug()
+    window = _window()
+
+    evlib_tensor = aug._flip_tensor(window)
+    rvt_tensor = RandomSpatialAugmentorGenX._flip_tensor(
+        window.clone(), flip_type="h", datatype=DataType.EV_REPR
+    )
+    assert np.array_equal(evlib_tensor.numpy(), rvt_tensor.numpy())
+    assert evlib_tensor.dtype == torch.uint8
+
+    evlib_box = aug._flip_box(_evlib_centre_box(), WIDTH)
+    labels = _rvt_object_labels()
+    labels.flip_lr_()
+    rvt_box = labels.get_labels_as_tensors("yolox")
+    assert torch.allclose(evlib_box, rvt_box)
+
+
+def test_rotate_bit_equivalent_to_rvt():
+    aug = _aug()
+    window = _window()
+    angle_deg = 90.0  # forced identical angle into both
+
+    evlib_tensor = aug._rotate_tensor(window, angle_deg)
+    rvt_tensor = RandomSpatialAugmentorGenX._rotate_tensor(
+        window.clone(), angle_deg=angle_deg, datatype=DataType.EV_REPR
+    )
+    assert np.array_equal(evlib_tensor.numpy(), rvt_tensor.numpy())
+
+    evlib_box = aug._rotate_box(_evlib_centre_box(), (HEIGHT, WIDTH), angle_deg)
+    labels = _rvt_object_labels()
+    labels.rotate_(angle_deg=angle_deg)
+    rvt_box = labels.get_labels_as_tensors("yolox")
+    assert torch.allclose(evlib_box, rvt_box)
+
+
+def test_zoom_out_bit_equivalent_to_rvt():
+    aug = _aug()
+    window = _window()
+    factor = 2.0
+    x0, y0 = 1, 1  # forced identical placement into both
+
+    evlib_tensor = aug._zoom_out_tensor(window, x0, y0, factor)
+    rvt_tensor = RandomSpatialAugmentorGenX._zoom_out_and_rescale_tensor(
+        window.clone(),
+        zoom_coordinates_x0y0=(x0, y0),
+        zoom_out_factor=factor,
+        datatype=DataType.EV_REPR,
+    )
+    assert np.array_equal(evlib_tensor.numpy(), rvt_tensor.numpy())
+
+    evlib_box = aug._zoom_out_box(_evlib_centre_box(), (HEIGHT, WIDTH), x0, y0, factor)
+    labels = _rvt_object_labels()
+    labels.zoom_out_and_rescale_(zoom_coordinates_x0y0=(x0, y0), zoom_out_factor=factor)
+    rvt_box = labels.get_labels_as_tensors("yolox")
+    assert torch.allclose(evlib_box, rvt_box)
+
+
+def test_zoom_in_bit_equivalent_to_rvt():
+    aug = _aug()
+    window = _window()
+    factor = 2.0
+    zoom_x0, zoom_y0 = 1, 1  # forced identical crop window into both
+
+    evlib_tensor = aug._zoom_in_tensor(window, zoom_x0, zoom_y0, factor)
+    rvt_tensor = RandomSpatialAugmentorGenX._zoom_in_and_rescale_tensor(
+        window.clone(),
+        zoom_coordinates_x0y0=(zoom_x0, zoom_y0),
+        zoom_in_factor=factor,
+        datatype=DataType.EV_REPR,
+    )
+    assert np.array_equal(evlib_tensor.numpy(), rvt_tensor.numpy())
+
+    evlib_box = aug._zoom_in_box(
+        _evlib_centre_box(), (HEIGHT, WIDTH), zoom_x0, zoom_y0, factor
+    )
+    labels = _rvt_object_labels()
+    labels.zoom_in_and_rescale_(
+        zoom_coordinates_x0y0=(zoom_x0, zoom_y0), zoom_in_factor=factor
+    )
+    rvt_box = labels.get_labels_as_tensors("yolox")
+    assert evlib_box is not None and rvt_box.numel() > 0
+    assert torch.allclose(evlib_box, rvt_box)

--- a/tests/test_data_augment_seam.py
+++ b/tests/test_data_augment_seam.py
@@ -1,0 +1,173 @@
+"""CI-tier tests for the SequenceAugmentor seam in the datasets + DataModule.
+
+These verify the wiring (the opt-in ``augmentor`` arg is threaded through and
+called with the right semantics), not the augmentation math itself, which is
+covered exhaustively in ``test_data_augment.py``. The random dataset draws fresh
+params PER ``__getitem__`` (RVT random semantics), while the stream dataset draws
+params ONCE per source and reuses them across every chunk of that source (RVT
+stream semantics).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import List
+
+import pytest
+
+pytest.importorskip("h5py")
+pytest.importorskip("hdf5plugin")
+
+from evlib.data.dataset_random import SequenceRandomDataset
+from evlib.data.dataset_stream import SequenceStreamDataset
+from evlib.data.sequence import SequenceSample
+from evlib.data.sources import PreprocessedH5Source
+
+FIX = Path(__file__).resolve().parent / "data_fixtures" / "mini_seq"
+
+
+class _TaggingAugmentor:
+    """A recording stub that counts calls and tags the sample it returns.
+
+    It returns a NEW ``SequenceSample`` so the dataset must use the augmentor's
+    output (not the pre-augmentation sample) for the test to pass. ``draws``
+    counts how many independent param draws happened, ``applies`` counts how many
+    samples were transformed.
+    """
+
+    def __init__(self) -> None:
+        self.applies = 0
+        self.returned: List[SequenceSample] = []
+
+    def __call__(self, sample: SequenceSample) -> SequenceSample:
+        self.applies += 1
+        out = SequenceSample(
+            ev_repr=[t.clone() for t in sample.ev_repr],
+            labels=list(sample.labels),
+            is_first_sample=sample.is_first_sample,
+            is_padded_mask=list(sample.is_padded_mask),
+        )
+        self.returned.append(out)
+        return out
+
+
+def test_random_dataset_applies_augmentor_once_per_getitem():
+    aug = _TaggingAugmentor()
+    ds = SequenceRandomDataset(
+        [PreprocessedH5Source(FIX)], sequence_length=4, augmentor=aug
+    )
+    assert aug.applies == 0  # construction does not augment
+    s0 = ds[0]
+    assert aug.applies == 1  # one __getitem__ -> exactly one augmentor call
+    # The returned sample is the augmentor's output, not the raw sample.
+    assert s0 is aug.returned[-1]
+    s1 = ds[1]
+    assert aug.applies == 2  # a second __getitem__ -> a second call
+    assert s1 is aug.returned[-1]
+
+
+def test_random_dataset_without_augmentor_is_untouched():
+    ds = SequenceRandomDataset([PreprocessedH5Source(FIX)], sequence_length=4)
+    s0 = ds[0]
+    assert isinstance(s0, SequenceSample)  # no augmentor: plain assembled sample
+
+
+class _CountingSourceAugmentor:
+    """Records once-per-source draws vs per-chunk applications for the stream path.
+
+    ``for_source(sample)`` is the per-source entry point: it draws a frozen
+    parameter state once and returns a per-chunk callable. Each invocation of
+    that callable counts as one application but reuses the single frozen draw.
+    """
+
+    def __init__(self) -> None:
+        self.draws = 0
+        self.applies = 0
+
+    def for_source(self, sample: SequenceSample):
+        self.draws += 1
+
+        def apply(chunk: SequenceSample) -> SequenceSample:
+            self.applies += 1
+            return chunk
+
+        return apply
+
+
+def test_stream_dataset_draws_params_once_per_source():
+    aug = _CountingSourceAugmentor()
+    # mini_seq has 6 windows; L=2 -> 3 chunks from the single source.
+    ds = SequenceStreamDataset(
+        [PreprocessedH5Source(FIX)],
+        sequence_length=2,
+        batch_size=1,
+        augmentor=aug,
+    )
+    steps = list(iter(ds))
+    assert len(steps) == 3
+    # ONE param draw for the single source, but applied to every real chunk.
+    assert aug.draws == 1
+    assert aug.applies == 3
+
+
+def test_stream_dataset_two_sources_draw_once_each():
+    aug = _CountingSourceAugmentor()
+    ds = SequenceStreamDataset(
+        [PreprocessedH5Source(FIX), PreprocessedH5Source(FIX)],
+        sequence_length=2,
+        batch_size=1,  # both sources land in slot 0 and stream back to back
+        augmentor=aug,
+    )
+    list(iter(ds))
+    # One draw per source (two sources), applied to all 3 chunks of each.
+    assert aug.draws == 2
+    assert aug.applies == 6
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("pytorch_lightning") is None,
+    reason="pytorch_lightning not installed",
+)
+def test_datamodule_augments_train_only():
+    import evlib.data as d
+
+    aug = _TaggingAugmentor()
+    dm = d.EventDataModule(
+        train_sources=[PreprocessedH5Source(FIX)],
+        val_sources=[PreprocessedH5Source(FIX)],
+        sequence_length=4,
+        batch_size=1,
+        num_workers=0,
+        sampling="random",
+        augmentor=aug,
+    )
+    train_ds = dm.train_dataloader().dataset
+    assert train_ds.augmentor is aug  # train split carries the augmentor
+    val_ds = dm.val_dataloader().dataset
+    assert val_ds.augmentor is None  # val split must NOT augment
+    test_ds = dm.test_dataloader().dataset
+    assert test_ds.augmentor is None  # test split must NOT augment
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("pytorch_lightning") is None,
+    reason="pytorch_lightning not installed",
+)
+def test_datamodule_stream_augments_train_only():
+    import evlib.data as d
+
+    aug = _CountingSourceAugmentor()
+    dm = d.EventDataModule(
+        train_sources=[PreprocessedH5Source(FIX)],
+        val_sources=[PreprocessedH5Source(FIX)],
+        sequence_length=4,
+        batch_size=1,
+        num_workers=0,
+        sampling="stream",
+        augmentor=aug,
+    )
+    train_ds = dm.train_dataloader().dataset
+    assert train_ds.augmentor is aug
+    # val/test stay random and unaugmented.
+    assert dm.val_dataloader().dataset.augmentor is None

--- a/tests/test_data_dataset_stream.py
+++ b/tests/test_data_dataset_stream.py
@@ -5,8 +5,11 @@ import pytest
 pytest.importorskip("h5py")
 pytest.importorskip("hdf5plugin")
 
+import numpy as np
+
 from evlib.data.sources import PreprocessedH5Source
 from evlib.data.dataset_stream import SequenceStreamDataset
+from evlib.data.augment import SequenceAugmentor
 from evlib.data.collate import custom_collate_stream
 from evlib.data.sequence import DataKey
 
@@ -71,6 +74,36 @@ def test_stream_slot0_exhausts_first_keeps_width_and_alignment():
         real_sample = later[1]
         assert real_sample.is_first_sample is False
         assert any(p is False for p in real_sample.is_padded_mask)
+
+
+def test_stream_rejects_random_sampler_augmentor_eagerly():
+    # A sampler='random' augmentor can draw label-aware zoom-in, which cannot be
+    # frozen once per source. Construction must fail EAGERLY (no iteration), not
+    # lazily when for_source() first draws zoom-in mid-iteration.
+    random_aug = SequenceAugmentor(sampler="random", rng=np.random.default_rng(0))
+    assert random_aug.stream_safe() is False
+    with pytest.raises(ValueError):
+        SequenceStreamDataset(
+            [PreprocessedH5Source(FIX)],
+            sequence_length=2,
+            batch_size=1,
+            augmentor=random_aug,
+        )
+
+
+def test_stream_accepts_stream_sampler_augmentor():
+    # A sampler='stream' augmentor disables zoom-in (zoom_in_weight=0) and so is
+    # stream-safe: construction succeeds and iteration yields the chunks.
+    stream_aug = SequenceAugmentor(sampler="stream", rng=np.random.default_rng(0))
+    assert stream_aug.stream_safe() is True
+    ds = SequenceStreamDataset(
+        [PreprocessedH5Source(FIX)],
+        sequence_length=2,
+        batch_size=1,
+        augmentor=stream_aug,
+    )
+    chunks = list(iter(ds))
+    assert len(chunks) == 3  # mini_seq 6 windows / L=2
 
 
 def test_stream_batch_size_exceeds_sources_pads_trailing_slot():

--- a/tests/test_data_label_preprocess.py
+++ b/tests/test_data_label_preprocess.py
@@ -407,6 +407,42 @@ def test_grid_with_jittered_frame_interior_edges():
     ]
 
 
+def test_grid_single_object_frame_branch():
+    # Exactly ONE selected object frame exercises the single-frame grid branch
+    # (the `len(frame_timestamps_us) == 1` path that appends the frame edge
+    # directly, with no linspace iterations). The 60 Hz backbone ends just after
+    # 100002 so only one unique ts is at/after align_t_us=100000.
+    dense = np.arange(0, 100003, 16667, dtype="int64")
+    # backbone: [0, 16667, 33334, 50001, 66668, 83335, 100002]; median diff
+    # 16667 -> 60 Hz -> base_delta 100002. first ts >= 100000 is 100002 and it
+    # is the last one, so no further frame is accepted: a single frame.
+    assert dense.tolist() == [0, 16667, 33334, 50001, 66668, 83335, 100002]
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+
+    # Exactly one selected frame at 100002.
+    assert result.frame_timestamps_us.tolist() == [100002]
+    # Back-fill range(100002, 0, -50000) = [100002, 50002, 2502]; reversed =
+    # [2502, 50002, 100002]; [1:-1] drops the 0-side and frame edges -> [50002].
+    # No linspace iterations (no frame gaps). The single-frame branch then
+    # appends the frame edge directly -> grid == [50002, 100002].
+    assert result.ev_repr_timestamps_us_end.tolist() == [50002, 100002]
+    assert result.ev_repr_timestamps_us_end.dtype == np.int64
+    # searchsorted([50002, 100002], [100002], side="left") -> [1].
+    assert result.objframe_idx_2_repr_idx.tolist() == [1]
+    assert result.objframe_idx_2_repr_idx.dtype == np.int64
+    # The grid lands exactly on the single frame.
+    assert np.array_equal(
+        result.frame_timestamps_us,
+        result.ev_repr_timestamps_us_end[result.objframe_idx_2_repr_idx],
+    )
+    # Only the single box at t=100002 is grouped (one box per frame here).
+    assert result.objframe_idx_2_label_idx.tolist() == [0]
+    assert result.objframe_idx_2_label_idx.dtype == np.int64
+    assert len(result.labels) == 1
+    assert result.labels["t"].tolist() == [100002]
+    assert result.labels.dtype == BBOX_DTYPE
+
+
 # --- build_objframes_and_grid: grouping --------------------------------------
 
 

--- a/tests/test_data_label_preprocess.py
+++ b/tests/test_data_label_preprocess.py
@@ -11,6 +11,7 @@ import pytest
 
 from evlib.data.label_preprocess import (
     BBOX_DTYPE,
+    EVLIB_REPR_DIR_NAME,
     RVT_REPR_DIR_NAME,
     NoLabelsError,
     ObjframeGridResult,
@@ -451,19 +452,19 @@ def test_grouping_concatenates_boxes_with_int64_offsets():
 # --- write_preprocessed: round-trip ------------------------------------------
 
 
-def test_write_preprocessed_roundtrip_exact_filenames(tmp_path):
+def test_write_preprocessed_default_uses_evlib_repr_dir_name(tmp_path):
+    """Default repr_dir_name is the evlib-native no-= form (EVLIB_REPR_DIR_NAME)."""
     dense = np.arange(0, 350000, 16667, dtype="int64")
     result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
     write_preprocessed(tmp_path, result)
 
+    assert EVLIB_REPR_DIR_NAME == "stacked_histogram_dt50_nbins10"
     labels_npz = tmp_path / "labels_v2" / "labels.npz"
     labels_ts = tmp_path / "labels_v2" / "timestamps_us.npy"
-    repr_dir = tmp_path / "event_representations_v2" / RVT_REPR_DIR_NAME
+    repr_dir = tmp_path / "event_representations_v2" / EVLIB_REPR_DIR_NAME
     repr_idx_file = repr_dir / "objframe_idx_2_repr_idx.npy"
     repr_ts_file = repr_dir / "timestamps_us.npy"
 
-    # Exact RVT on-disk layout, including the ``=`` in the repr dir name.
-    assert RVT_REPR_DIR_NAME == "stacked_histogram_dt=50_nbins=10"
     assert labels_npz.exists()
     assert labels_ts.exists()
     assert repr_idx_file.exists()
@@ -477,6 +478,19 @@ def test_write_preprocessed_roundtrip_exact_filenames(tmp_path):
     assert np.array_equal(np.load(str(labels_ts)), result.frame_timestamps_us)
     assert np.array_equal(np.load(str(repr_idx_file)), result.objframe_idx_2_repr_idx)
     assert np.array_equal(np.load(str(repr_ts_file)), result.ev_repr_timestamps_us_end)
+
+
+def test_write_preprocessed_explicit_rvt_repr_dir_name(tmp_path):
+    """Passing repr_dir_name=RVT_REPR_DIR_NAME produces the = form expected by RVT."""
+    dense = np.arange(0, 250000, 16667, dtype="int64")
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+    write_preprocessed(tmp_path, result, repr_dir_name=RVT_REPR_DIR_NAME)
+
+    assert RVT_REPR_DIR_NAME == "stacked_histogram_dt=50_nbins=10"
+    repr_dir = tmp_path / "event_representations_v2" / RVT_REPR_DIR_NAME
+    assert repr_dir.is_dir()
+    assert (repr_dir / "objframe_idx_2_repr_idx.npy").exists()
+    assert (repr_dir / "timestamps_us.npy").exists()
 
 
 def test_write_preprocessed_honours_custom_repr_dir_name(tmp_path):
@@ -511,6 +525,7 @@ def test_preprocess_sequence_end_to_end(tmp_path):
     assert result.objframe_idx_2_label_idx.tolist() == [0, 1, 2]
     assert 999 not in result.labels["track_id"].tolist()
     assert (out_dir / "labels_v2" / "labels.npz").exists()
+    # Default repr_dir_name is the evlib-native no-= form.
     assert (
-        out_dir / "event_representations_v2" / RVT_REPR_DIR_NAME / "timestamps_us.npy"
+        out_dir / "event_representations_v2" / EVLIB_REPR_DIR_NAME / "timestamps_us.npy"
     ).exists()

--- a/tests/test_data_label_preprocess.py
+++ b/tests/test_data_label_preprocess.py
@@ -1,0 +1,280 @@
+"""TDD tests for RVT bbox filter chain (label preprocessing, task B1).
+
+Small real structured arrays of the exact on-disk 8-field dtype exercise each
+filter's known-kept/known-dropped members and the boundary cases from the brief.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from evlib.data.label_preprocess import (
+    BBOX_DTYPE,
+    NoLabelsError,
+    apply_filters,
+    conservative_size_filter,
+    crop_to_fov,
+    keep_classes_gen4,
+    prophesee_size_filter,
+    read_raw_bbox,
+    remove_faulty_huge_bbox,
+)
+
+GEN4_HEIGHT = 720
+GEN4_WIDTH = 1280
+
+
+def make_bbox(rows) -> np.ndarray:
+    """Build a structured bbox array of the exact on-disk dtype from row tuples.
+
+    Each row is (t, x, y, w, h, class_id, class_confidence, track_id).
+    """
+    return np.array(rows, dtype=BBOX_DTYPE)
+
+
+def test_bbox_dtype_field_order_and_types():
+    expected = [
+        ("t", "<u8"),
+        ("x", "<f4"),
+        ("y", "<f4"),
+        ("w", "<f4"),
+        ("h", "<f4"),
+        ("class_id", "|u1"),
+        ("class_confidence", "<f4"),
+        ("track_id", "<u4"),
+    ]
+    assert BBOX_DTYPE.descr == expected
+
+
+# --- read_raw_bbox -----------------------------------------------------------
+
+
+def test_read_raw_bbox_roundtrip(tmp_path):
+    arr = make_bbox(
+        [
+            (10, 1.0, 2.0, 30.0, 40.0, 0, 0.9, 7),
+            (20, 5.0, 6.0, 50.0, 60.0, 2, 0.8, 8),
+        ]
+    )
+    path = tmp_path / "seq_bbox.npy"
+    np.save(path, arr)
+    loaded = read_raw_bbox(path)
+    assert loaded.dtype == BBOX_DTYPE
+    assert np.array_equal(loaded, arr)
+
+
+def test_read_raw_bbox_rejects_wrong_fields(tmp_path):
+    wrong = np.array(
+        [(1, 2.0, 3.0)],
+        dtype=[("t", "<u8"), ("x", "<f4"), ("y", "<f4")],
+    )
+    path = tmp_path / "bad_bbox.npy"
+    np.save(path, wrong)
+    with pytest.raises(ValueError) as exc:
+        read_raw_bbox(path)
+    assert str(path) in str(exc.value)
+
+
+# --- keep_classes_gen4 -------------------------------------------------------
+
+
+def test_keep_classes_gen4_keeps_0_1_2_drops_3_to_6():
+    labels = make_bbox(
+        [(1, 0.0, 0.0, 10.0, 10.0, cls, 1.0, cls) for cls in (0, 1, 2, 3, 4, 5, 6)]
+    )
+    kept = keep_classes_gen4(labels)
+    assert sorted(kept["class_id"].tolist()) == [0, 1, 2]
+    # track_id carried through on the kept rows.
+    assert sorted(kept["track_id"].tolist()) == [0, 1, 2]
+
+
+# --- crop_to_fov -------------------------------------------------------------
+
+
+def test_crop_to_fov_clamps_negative_x_and_recomputes_w():
+    # x=-10, w=50 -> x clamped to 0; right edge = -10 + 50 = 40 -> w = 40.
+    labels = make_bbox([(1, -10.0, 5.0, 50.0, 30.0, 0, 0.5, 11)])
+    cropped = crop_to_fov(labels, GEN4_HEIGHT, GEN4_WIDTH)
+    assert cropped.shape[0] == 1
+    assert cropped["x"][0] == 0.0
+    assert cropped["w"][0] == 40.0
+    assert cropped["y"][0] == 5.0
+    assert cropped["h"][0] == 30.0
+    assert cropped["track_id"][0] == 11
+
+
+def test_crop_to_fov_clamps_right_edge_to_width_minus_one():
+    # Right edge well past the frame: x=1270, w=100 -> right clamped to W-1=1279.
+    labels = make_bbox([(1, 1270.0, 10.0, 100.0, 30.0, 1, 0.5, 12)])
+    cropped = crop_to_fov(labels, GEN4_HEIGHT, GEN4_WIDTH)
+    assert cropped.shape[0] == 1
+    assert cropped["x"][0] == 1270.0
+    # 1279 - 1270 = 9, NOT 1280 - 1270 = 10 (W-1 bound matters).
+    assert cropped["w"][0] == 9.0
+
+
+def test_crop_to_fov_clamps_bottom_edge_to_height_minus_one():
+    labels = make_bbox([(1, 10.0, 710.0, 30.0, 100.0, 1, 0.5, 13)])
+    cropped = crop_to_fov(labels, GEN4_HEIGHT, GEN4_WIDTH)
+    assert cropped.shape[0] == 1
+    # 719 - 710 = 9, NOT 720 - 710 = 10.
+    assert cropped["h"][0] == 9.0
+
+
+def test_crop_to_fov_drops_box_fully_outside():
+    # Entirely left of the frame: x=-100, w=50 -> right edge -50, both clamp to 0.
+    labels = make_bbox(
+        [
+            (1, -100.0, 5.0, 50.0, 30.0, 0, 0.5, 21),
+            (2, 100.0, 5.0, 30.0, 30.0, 0, 0.5, 22),
+        ]
+    )
+    cropped = crop_to_fov(labels, GEN4_HEIGHT, GEN4_WIDTH)
+    assert cropped.shape[0] == 1
+    assert cropped["track_id"][0] == 22
+
+
+# --- conservative_size_filter ------------------------------------------------
+
+
+def test_conservative_size_filter_boundary_at_five():
+    labels = make_bbox(
+        [
+            (1, 0.0, 0.0, 5.0, 5.0, 0, 0.5, 31),  # exactly 5 -> kept
+            (2, 0.0, 0.0, 4.999, 10.0, 0, 0.5, 32),  # w < 5 -> dropped
+            (3, 0.0, 0.0, 10.0, 4.999, 0, 0.5, 33),  # h < 5 -> dropped
+            (4, 0.0, 0.0, 6.0, 6.0, 0, 0.5, 34),  # both > 5 -> kept
+        ]
+    )
+    kept = conservative_size_filter(labels)
+    assert sorted(kept["track_id"].tolist()) == [31, 34]
+
+
+# --- prophesee_size_filter (gen1 branch, diag/side) --------------------------
+
+
+def test_prophesee_size_filter_gen4_diag_and_side():
+    # gen4: min_box_diag=60, min_box_side=20.
+    labels = make_bbox(
+        [
+            (1, 0.0, 0.0, 20.0, 60.0, 0, 0.5, 41),  # side ok, diag sqrt(400+3600)=63 ok
+            (2, 0.0, 0.0, 19.0, 60.0, 0, 0.5, 42),  # side < 20 -> dropped
+            (3, 0.0, 0.0, 30.0, 30.0, 0, 0.5, 43),  # diag sqrt(1800)=42 < 60 -> dropped
+            (4, 0.0, 0.0, 50.0, 50.0, 0, 0.5, 44),  # both ok
+        ]
+    )
+    kept = prophesee_size_filter(labels, "gen4")
+    assert sorted(kept["track_id"].tolist()) == [41, 44]
+
+
+# --- remove_faulty_huge_bbox -------------------------------------------------
+
+
+def test_remove_faulty_huge_bbox_drops_above_threshold():
+    max_width = (9 * GEN4_WIDTH) // 10  # 1152
+    labels = make_bbox(
+        [
+            (1, 0.0, 0.0, float(max_width), 10.0, 0, 0.5, 51),  # == max -> kept
+            (2, 0.0, 0.0, float(max_width + 1), 10.0, 0, 0.5, 52),  # > max -> dropped
+        ]
+    )
+    kept = remove_faulty_huge_bbox(labels, GEN4_WIDTH)
+    assert sorted(kept["track_id"].tolist()) == [51]
+
+
+# --- apply_filters: split-conditional faulty filter --------------------------
+
+
+def _huge_box_array():
+    # w = 1200 > (9*1280)//10 = 1152 -> only dropped on train.
+    return make_bbox(
+        [
+            (1, 0.0, 0.0, 1200.0, 30.0, 0, 0.5, 61),
+            (2, 0.0, 0.0, 50.0, 50.0, 1, 0.5, 62),
+        ]
+    )
+
+
+def test_apply_filters_faulty_drops_on_train():
+    kept = apply_filters(
+        _huge_box_array(),
+        dataset="gen4",
+        split="train",
+        height=GEN4_HEIGHT,
+        width=GEN4_WIDTH,
+    )
+    assert kept["track_id"].tolist() == [62]
+
+
+def test_apply_filters_faulty_kept_on_val():
+    kept = apply_filters(
+        _huge_box_array(),
+        dataset="gen4",
+        split="val",
+        height=GEN4_HEIGHT,
+        width=GEN4_WIDTH,
+    )
+    assert sorted(kept["track_id"].tolist()) == [61, 62]
+
+
+# --- apply_filters: full chain on a mixed array ------------------------------
+
+
+def test_apply_filters_full_chain_mixed_array():
+    labels = make_bbox(
+        [
+            # class 4 (traffic sign) -> dropped by class filter
+            (1, 100.0, 100.0, 50.0, 50.0, 4, 0.5, 71),
+            # negative x clamped, then large enough -> kept
+            (2, -10.0, 5.0, 60.0, 60.0, 0, 0.9, 72),
+            # tiny box (w<5 after no crop) -> dropped by conservative size
+            (3, 200.0, 200.0, 4.0, 100.0, 1, 0.8, 73),
+            # class 2 car, valid size -> kept
+            (4, 300.0, 300.0, 40.0, 40.0, 2, 0.7, 74),
+        ]
+    )
+    kept = apply_filters(
+        labels,
+        dataset="gen4",
+        split="val",
+        height=GEN4_HEIGHT,
+        width=GEN4_WIDTH,
+    )
+    # Order preserved: row 72 then 74.
+    assert kept["track_id"].tolist() == [72, 74]
+    # crop applied to row 72: x=-10 -> 0, right edge -10+60=50 -> w=50.
+    row72 = kept[kept["track_id"] == 72][0]
+    assert row72["x"] == 0.0
+    assert row72["w"] == 50.0
+    # class_confidence carried through.
+    assert row72["class_confidence"] == np.float32(0.9)
+    assert kept[kept["track_id"] == 74][0]["class_confidence"] == np.float32(0.7)
+
+
+def test_apply_filters_raises_when_all_removed():
+    # Single class-4 box -> removed by class filter -> zero boxes.
+    labels = make_bbox([(1, 100.0, 100.0, 50.0, 50.0, 4, 0.5, 81)])
+    with pytest.raises(NoLabelsError):
+        apply_filters(
+            labels,
+            dataset="gen4",
+            split="val",
+            height=GEN4_HEIGHT,
+            width=GEN4_WIDTH,
+        )
+
+
+def test_apply_filters_psee_branch_uses_prophesee_size():
+    # With apply_psee_bbox_filter=True the prophesee (diag/side) filter runs.
+    # Box w=10,h=10: passes conservative (>=5) but fails gen4 side (>=20).
+    labels = make_bbox([(1, 100.0, 100.0, 10.0, 10.0, 0, 0.5, 91)])
+    with pytest.raises(NoLabelsError):
+        apply_filters(
+            labels,
+            dataset="gen4",
+            split="val",
+            height=GEN4_HEIGHT,
+            width=GEN4_WIDTH,
+            apply_psee_bbox_filter=True,
+        )

--- a/tests/test_data_label_preprocess.py
+++ b/tests/test_data_label_preprocess.py
@@ -11,14 +11,20 @@ import pytest
 
 from evlib.data.label_preprocess import (
     BBOX_DTYPE,
+    RVT_REPR_DIR_NAME,
     NoLabelsError,
+    ObjframeGridResult,
     apply_filters,
+    build_objframes_and_grid,
     conservative_size_filter,
     crop_to_fov,
+    get_base_delta_ts_us,
     keep_classes_gen4,
+    preprocess_sequence,
     prophesee_size_filter,
     read_raw_bbox,
     remove_faulty_huge_bbox,
+    write_preprocessed,
 )
 
 GEN4_HEIGHT = 720
@@ -278,3 +284,233 @@ def test_apply_filters_psee_branch_uses_prophesee_size():
             width=GEN4_WIDTH,
             apply_psee_bbox_filter=True,
         )
+
+
+# --- get_base_delta_ts_us: base label cadence --------------------------------
+
+
+def test_base_delta_gen1_fixed_4hz():
+    # gen1 is a fixed 4 Hz cadence regardless of the timestamps.
+    assert get_base_delta_ts_us(np.array([0, 250000], dtype="int64"), "gen1") == 250000
+
+
+def test_base_delta_gen4_60hz():
+    # 60 Hz dense cadence: median diff 16667, base_delta = 6 * 16667 = 100002.
+    unique_ts = np.arange(0, 200001, 16667, dtype="int64")
+    assert get_base_delta_ts_us(unique_ts, "gen4") == 100002
+
+
+def test_base_delta_gen4_30hz():
+    # 30 Hz dense cadence: median diff 33333, base_delta = 3 * 33333 = 99999.
+    unique_ts = np.arange(0, 400001, 33333, dtype="int64")
+    assert get_base_delta_ts_us(unique_ts, "gen4") == 99999
+
+
+def test_base_delta_gen4_rejects_off_cadence():
+    # 100 Hz (median diff 10000) is neither 30 nor 60 Hz -> rejected.
+    unique_ts = np.arange(0, 100001, 10000, dtype="int64")
+    with pytest.raises(ValueError):
+        get_base_delta_ts_us(unique_ts, "gen4")
+
+
+# --- build_objframes_and_grid: frame selection -------------------------------
+
+
+def _one_box_per_ts(timestamps) -> np.ndarray:
+    """One valid box per timestamp, sorted by t, with distinct track_ids."""
+    rows = [
+        (int(ts), 0.0, 0.0, 40.0, 40.0, 2, 0.9, track)
+        for track, ts in enumerate(sorted(timestamps))
+    ]
+    return make_bbox(rows)
+
+
+def test_frame_selection_natural_60hz_cadence():
+    # Dense 60 Hz backbone -> base_delta 100002. align_t_us=100000 picks the
+    # first ts >= 100000 (= 100002), then every ~100002 us afterwards.
+    dense = np.arange(0, 450000, 16667, dtype="int64")
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+    assert result.frame_timestamps_us.tolist() == [100002, 200004, 300006, 400008]
+    assert result.frame_timestamps_us.dtype == np.int64
+
+
+def test_frame_selection_accepts_jitter_within_tolerance():
+    # Perturb the second selected frame by +1500 us (within the 2000 us jitter).
+    dense = list(np.arange(0, 350000, 16667, dtype="int64"))
+    dense = [201504 if v == 200004 else v for v in dense]
+    timestamps = sorted(set(dense))
+    result = build_objframes_and_grid(_one_box_per_ts(timestamps), dataset="gen4")
+    # 201504 is accepted despite the jitter; cadence resumes from it.
+    assert result.frame_timestamps_us.tolist() == [100002, 201504, 300006]
+
+
+def test_frame_selection_rejects_off_cadence_near_miss():
+    # Extra ts at 202504 is a near-miss (2500 us past a multiple, > tolerance)
+    # and must be rejected; the clean 60 Hz frames are kept.
+    dense = list(np.arange(0, 350000, 16667, dtype="int64"))
+    dense.append(202504)
+    timestamps = sorted(set(dense))
+    result = build_objframes_and_grid(_one_box_per_ts(timestamps), dataset="gen4")
+    assert 202504 not in result.frame_timestamps_us.tolist()
+    assert result.frame_timestamps_us.tolist() == [100002, 200004, 300006]
+
+
+# --- build_objframes_and_grid: window-end grid -------------------------------
+
+
+def test_grid_backfill_linspace_and_dropped_edge():
+    # Clean 60 Hz, frames [100002, 200004, 300006]. base_delta 100002 ->
+    # num_ev_reprs_between = 2 per gap, so each segment has a single interior edge.
+    dense = np.arange(0, 350000, 16667, dtype="int64")
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+    # Back-fill from 100002 down by 50000, dropping 0 and the frame edge: [50002].
+    # Segment 1: linspace(100002, 200004, 3) = [100002, 150003, 200004], shared
+    # edge 200004 dropped (not last segment) -> [100002, 150003].
+    # Segment 2 (last): linspace(200004, 300006, 3) = [200004, 250005, 300006],
+    # kept whole.
+    assert result.ev_repr_timestamps_us_end.tolist() == [
+        50002,
+        100002,
+        150003,
+        200004,
+        250005,
+        300006,
+    ]
+    assert result.ev_repr_timestamps_us_end.dtype == np.int64
+
+
+def test_grid_lands_exactly_on_frames_via_searchsorted():
+    dense = np.arange(0, 350000, 16667, dtype="int64")
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+    grid = result.ev_repr_timestamps_us_end
+    repr_idx = result.objframe_idx_2_repr_idx
+    assert repr_idx.tolist() == [1, 3, 5]
+    assert repr_idx.dtype == np.int64
+    # The searchsorted alignment lands the grid exactly on every frame.
+    assert np.array_equal(result.frame_timestamps_us, grid[repr_idx])
+
+
+def test_grid_with_jittered_frame_interior_edges():
+    dense = list(np.arange(0, 350000, 16667, dtype="int64"))
+    dense = [201504 if v == 200004 else v for v in dense]
+    timestamps = sorted(set(dense))
+    result = build_objframes_and_grid(_one_box_per_ts(timestamps), dataset="gen4")
+    # Frames [100002, 201504, 300006]; interior linspace edges shift with jitter.
+    assert result.ev_repr_timestamps_us_end.tolist() == [
+        50002,
+        100002,
+        150753,
+        201504,
+        250755,
+        300006,
+    ]
+
+
+# --- build_objframes_and_grid: grouping --------------------------------------
+
+
+def test_grouping_concatenates_boxes_with_int64_offsets():
+    # Two boxes at frame 100002, one at 200004, three at 300006.
+    rows = []
+    track = 0
+    for ts, count in [(100002, 2), (200004, 1), (300006, 3)]:
+        for _ in range(count):
+            rows.append((ts, 0.0, 0.0, 40.0, 40.0, 2, 0.9, track))
+            track += 1
+    # Include the dense backbone (one box each) so base_delta resolves to 60 Hz.
+    backbone = [
+        int(v)
+        for v in np.arange(0, 350000, 16667)
+        if int(v) not in {100002, 200004, 300006}
+    ]
+    for ts in backbone:
+        rows.append((ts, 0.0, 0.0, 40.0, 40.0, 2, 0.9, track))
+        track += 1
+    rows.sort(key=lambda r: r[0])
+    result = build_objframes_and_grid(make_bbox(rows), dataset="gen4")
+
+    assert result.frame_timestamps_us.tolist() == [100002, 200004, 300006]
+    # Per-frame box counts: 2 (+0 backbone), 1, 3 -> offsets [0, 2, 3].
+    assert result.objframe_idx_2_label_idx.tolist() == [0, 2, 3]
+    assert result.objframe_idx_2_label_idx.dtype == np.int64
+    # Concatenated grouped labels: 2 + 1 + 3 = 6 boxes, all at selected frames.
+    assert len(result.labels) == 6
+    assert result.labels["t"].tolist() == [
+        100002,
+        100002,
+        200004,
+        300006,
+        300006,
+        300006,
+    ]
+    # track_id is carried through the grouping.
+    assert set(result.labels["track_id"].tolist()) == set(range(6))
+    assert result.labels.dtype == BBOX_DTYPE
+
+
+# --- write_preprocessed: round-trip ------------------------------------------
+
+
+def test_write_preprocessed_roundtrip_exact_filenames(tmp_path):
+    dense = np.arange(0, 350000, 16667, dtype="int64")
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+    write_preprocessed(tmp_path, result)
+
+    labels_npz = tmp_path / "labels_v2" / "labels.npz"
+    labels_ts = tmp_path / "labels_v2" / "timestamps_us.npy"
+    repr_dir = tmp_path / "event_representations_v2" / RVT_REPR_DIR_NAME
+    repr_idx_file = repr_dir / "objframe_idx_2_repr_idx.npy"
+    repr_ts_file = repr_dir / "timestamps_us.npy"
+
+    # Exact RVT on-disk layout, including the ``=`` in the repr dir name.
+    assert RVT_REPR_DIR_NAME == "stacked_histogram_dt=50_nbins=10"
+    assert labels_npz.exists()
+    assert labels_ts.exists()
+    assert repr_idx_file.exists()
+    assert repr_ts_file.exists()
+
+    loaded = np.load(str(labels_npz))
+    assert np.array_equal(loaded["labels"], result.labels)
+    assert np.array_equal(
+        loaded["objframe_idx_2_label_idx"], result.objframe_idx_2_label_idx
+    )
+    assert np.array_equal(np.load(str(labels_ts)), result.frame_timestamps_us)
+    assert np.array_equal(np.load(str(repr_idx_file)), result.objframe_idx_2_repr_idx)
+    assert np.array_equal(np.load(str(repr_ts_file)), result.ev_repr_timestamps_us_end)
+
+
+def test_write_preprocessed_honours_custom_repr_dir_name(tmp_path):
+    dense = np.arange(0, 250000, 16667, dtype="int64")
+    result = build_objframes_and_grid(_one_box_per_ts(dense), dataset="gen4")
+    write_preprocessed(tmp_path, result, repr_dir_name="custom_repr")
+    assert (tmp_path / "event_representations_v2" / "custom_repr").is_dir()
+
+
+# --- preprocess_sequence: end-to-end -----------------------------------------
+
+
+def test_preprocess_sequence_end_to_end(tmp_path):
+    # A raw bbox file with a class-4 box (dropped by filters) plus valid boxes
+    # on a 60 Hz backbone; preprocess_sequence reads, filters, aligns, writes.
+    dense = np.arange(0, 350000, 16667, dtype="int64")
+    rows = [
+        (int(ts), 0.0, 0.0, 40.0, 40.0, 2, 0.9, track) for track, ts in enumerate(dense)
+    ]
+    # A traffic-sign (class 4) box at a frame ts; must be filtered out.
+    rows.append((100002, 0.0, 0.0, 40.0, 40.0, 4, 0.9, 999))
+    rows.sort(key=lambda r: r[0])
+    bbox_path = tmp_path / "seq_bbox.npy"
+    np.save(bbox_path, make_bbox(rows))
+
+    out_dir = tmp_path / "out"
+    result = preprocess_sequence(bbox_path, out_dir, dataset="gen4", split="val")
+
+    assert isinstance(result, ObjframeGridResult)
+    assert result.frame_timestamps_us.tolist() == [100002, 200004, 300006]
+    # The class-4 box was dropped: each selected frame keeps exactly one box.
+    assert result.objframe_idx_2_label_idx.tolist() == [0, 1, 2]
+    assert 999 not in result.labels["track_id"].tolist()
+    assert (out_dir / "labels_v2" / "labels.npz").exists()
+    assert (
+        out_dir / "event_representations_v2" / RVT_REPR_DIR_NAME / "timestamps_us.npy"
+    ).exists()

--- a/tests/test_data_label_preprocess_realdata.py
+++ b/tests/test_data_label_preprocess_realdata.py
@@ -1,0 +1,144 @@
+"""Byte-identical acceptance gate for RVT label preprocessing (task B3).
+
+Runs ``preprocess_sequence`` on a real raw ``*_bbox.npy`` and asserts the four
+written artifacts are array-equal (values AND dtype) to the real RVT-produced
+ground truth staged on disk. A mismatch is a real transcription bug in the B1
+filter chain or the B2 object-frame/grid alignment, to be fixed in
+``python/evlib/data/label_preprocess.py`` (never by relaxing this gate).
+
+Local-only ``slow`` gate. Skips cleanly when the staged data is absent (CI and
+machines without the gitignored sequence). Override the sequence directory via
+the ``EVLIB_GEN4_BBOX_SEQ_DIR`` environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from evlib.data.label_preprocess import preprocess_sequence
+
+SEQ_NAME = "moorea_2019-06-17_test_02_000_3172500000_3232500000"
+REPR_DIR_NAME = "stacked_histogram_dt=50_nbins=10"
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_SEQ_DIR = _PROJECT_ROOT / "data" / "gen4_label_preprocess" / SEQ_NAME
+
+
+def _seq_dir() -> Path:
+    override = os.environ.get("EVLIB_GEN4_BBOX_SEQ_DIR")
+    return Path(override) if override else _DEFAULT_SEQ_DIR
+
+
+def _assert_array_byte_identical(
+    name: str, produced: np.ndarray, expected: np.ndarray
+) -> None:
+    """Assert two arrays match exactly in dtype, shape and every value.
+
+    On mismatch the message names the first differing index and the two values
+    so a failure points straight at the responsible filter/alignment step.
+    """
+    assert produced.dtype == expected.dtype, (
+        f"{name}: dtype mismatch produced {produced.dtype} != expected {expected.dtype}"
+    )
+    assert produced.shape == expected.shape, (
+        f"{name}: shape mismatch produced {produced.shape} != expected {expected.shape}"
+    )
+    if np.array_equal(produced, expected):
+        return
+
+    if expected.dtype.names is not None:
+        # Structured array: report the first differing (row, field).
+        for row in range(expected.shape[0]):
+            for field in expected.dtype.names:
+                if not np.array_equal(produced[field][row], expected[field][row]):
+                    raise AssertionError(
+                        f"{name}: first diff at row {row} field {field!r}: "
+                        f"produced {produced[field][row]!r} != expected "
+                        f"{expected[field][row]!r}"
+                    )
+        raise AssertionError(f"{name}: arrays differ but no element diff located")
+
+    diff = np.flatnonzero(produced != expected)
+    first = int(diff[0])
+    raise AssertionError(
+        f"{name}: first diff at index {first}: produced {produced[first]!r} "
+        f"!= expected {expected[first]!r} ({diff.size} differing element(s))"
+    )
+
+
+@pytest.mark.slow
+def test_label_preprocess_byte_identical_to_rvt(tmp_path):
+    """preprocess_sequence reproduces RVT's five ground-truth arrays exactly."""
+    seq_dir = _seq_dir()
+    bbox_path = seq_dir / f"{SEQ_NAME}_bbox.npy"
+    if not seq_dir.is_dir() or not bbox_path.is_file():
+        pytest.skip(
+            f"staged gen4 bbox sequence not found at {seq_dir} "
+            "(set EVLIB_GEN4_BBOX_SEQ_DIR to override)"
+        )
+
+    preprocess_sequence(
+        bbox_path,
+        out_dir=tmp_path,
+        dataset="gen4",
+        split="val",
+        height=720,
+        width=1280,
+        repr_dir_name=REPR_DIR_NAME,
+    )
+
+    produced_labels_npz = np.load(tmp_path / "labels_v2" / "labels.npz")
+    expected_labels_npz = np.load(seq_dir / "labels_v2" / "labels.npz")
+
+    # 1. labels structured array (every field incl track_id, class_confidence).
+    _assert_array_byte_identical(
+        "labels",
+        produced_labels_npz["labels"],
+        expected_labels_npz["labels"],
+    )
+
+    # 2. objframe_idx_2_label_idx (int64).
+    _assert_array_byte_identical(
+        "objframe_idx_2_label_idx",
+        produced_labels_npz["objframe_idx_2_label_idx"],
+        expected_labels_npz["objframe_idx_2_label_idx"],
+    )
+
+    # 3. labels_v2/timestamps_us.npy (599 frame timestamps, int64).
+    _assert_array_byte_identical(
+        "labels_v2/timestamps_us",
+        np.load(tmp_path / "labels_v2" / "timestamps_us.npy"),
+        np.load(seq_dir / "labels_v2" / "timestamps_us.npy"),
+    )
+
+    # 4. objframe_idx_2_repr_idx.npy (599, int64).
+    _assert_array_byte_identical(
+        "objframe_idx_2_repr_idx",
+        np.load(
+            tmp_path
+            / "event_representations_v2"
+            / REPR_DIR_NAME
+            / "objframe_idx_2_repr_idx.npy"
+        ),
+        np.load(
+            seq_dir
+            / "event_representations_v2"
+            / REPR_DIR_NAME
+            / "objframe_idx_2_repr_idx.npy"
+        ),
+    )
+
+    # 5. event_representations_v2/<repr>/timestamps_us.npy (1198-window grid, int64).
+    _assert_array_byte_identical(
+        "event_representations/timestamps_us",
+        np.load(
+            tmp_path / "event_representations_v2" / REPR_DIR_NAME / "timestamps_us.npy"
+        ),
+        np.load(
+            seq_dir / "event_representations_v2" / REPR_DIR_NAME / "timestamps_us.npy"
+        ),
+    )

--- a/tests/test_data_ncaltech.py
+++ b/tests/test_data_ncaltech.py
@@ -1,0 +1,127 @@
+"""Tests for the N-Caltech101 ATIS `.bin` event reader.
+
+The fixtures are tiny, hand-encoded, genuine ATIS-format byte sequences
+written to ``tmp_path``. Each 5-byte event group is ``(b0, b1, b2, b3, b4)``
+with::
+
+    x = b0
+    y = b1
+    polarity = b2 >> 7
+    t_us = ((b2 & 0x7F) << 16) | (b3 << 8) | b4
+
+so the expected decodes below are computed by hand.
+"""
+
+import polars as pl
+import pytest
+
+from evlib.data.ncaltech import (
+    NCALTECH_HEIGHT,
+    NCALTECH_WIDTH,
+    read_atis_bin,
+)
+
+
+def test_sensor_constants():
+    assert NCALTECH_WIDTH == 240
+    assert NCALTECH_HEIGHT == 180
+
+
+def test_single_event_all_timestamp_bytes(tmp_path):
+    # b2 top bit set -> polarity 1; (b2 & 0x7F) == 0x7F.
+    # t_us = (0x7F << 16) | (0xAB << 8) | 0xCD = 0x7FABCD = 8366541.
+    b0, b1, b2, b3, b4 = 0x10, 0x20, 0xFF, 0xAB, 0xCD
+    path = tmp_path / "single.bin"
+    path.write_bytes(bytes([b0, b1, b2, b3, b4]))
+
+    frame = read_atis_bin(path)
+
+    assert frame.height == 1
+    row = frame.row(0, named=True)
+    assert row["x"] == 0x10
+    assert row["y"] == 0x20
+    assert row["polarity"] == 1
+    assert row["t"] == (0x7F << 16) | (0xAB << 8) | 0xCD
+    assert row["t"] == 0x7FABCD == 8367053
+
+
+def test_top_bit_does_not_leak_into_timestamp(tmp_path):
+    # Two events sharing the low 23 timestamp bits but differing top bit.
+    # event 0: b2 = 0x80 -> polarity 1, (b2 & 0x7F) == 0 -> t high byte 0.
+    # event 1: b2 = 0x00 -> polarity 0, (b2 & 0x7F) == 0 -> t high byte 0.
+    # both: t_us = (0 << 16) | (0x12 << 8) | 0x34 = 0x1234 = 4660.
+    raw = bytes(
+        [
+            0x05,
+            0x06,
+            0x80,
+            0x12,
+            0x34,
+            0x07,
+            0x08,
+            0x00,
+            0x12,
+            0x34,
+        ]
+    )
+    path = tmp_path / "polarity.bin"
+    path.write_bytes(raw)
+
+    frame = read_atis_bin(path)
+
+    assert frame.height == 2
+    first = frame.row(0, named=True)
+    second = frame.row(1, named=True)
+    assert first["polarity"] == 1
+    assert second["polarity"] == 0
+    assert first["t"] == 0x1234 == 4660
+    assert second["t"] == 0x1234 == 4660
+
+
+def test_multiple_events_file_order_and_dtypes(tmp_path):
+    raw = bytes(
+        [
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x01,  # t=1, pol=0
+            0xEF,
+            0xB3,
+            0x80,
+            0x00,
+            0x02,  # x=239, y=179, t=2, pol=1
+            0x01,
+            0x02,
+            0x03,
+            0x04,
+            0x05,  # t=(3<<16)|(4<<8)|5
+        ]
+    )
+    path = tmp_path / "multi.bin"
+    path.write_bytes(raw)
+
+    frame = read_atis_bin(path)
+
+    assert frame.columns == ["x", "y", "t", "polarity"]
+    assert frame.schema["x"] == pl.Int64
+    assert frame.schema["y"] == pl.Int64
+    assert frame.schema["t"] == pl.Int64
+    assert frame.schema["polarity"] == pl.Int64
+
+    assert frame["x"].to_list() == [0x00, 0xEF, 0x01]
+    assert frame["y"].to_list() == [0x00, 0xB3, 0x02]
+    assert frame["polarity"].to_list() == [0, 1, 0]
+    assert frame["t"].to_list() == [
+        1,
+        2,
+        (0x03 << 16) | (0x04 << 8) | 0x05,
+    ]
+
+
+def test_malformed_length_raises(tmp_path):
+    path = tmp_path / "bad.bin"
+    path.write_bytes(bytes([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))  # 6 bytes
+
+    with pytest.raises(ValueError, match=str(path)):
+        read_atis_bin(path)

--- a/tests/test_data_ncaltech.py
+++ b/tests/test_data_ncaltech.py
@@ -12,14 +12,39 @@ with::
 so the expected decodes below are computed by hand.
 """
 
+import numpy as np
 import polars as pl
 import pytest
 
 from evlib.data.ncaltech import (
     NCALTECH_HEIGHT,
     NCALTECH_WIDTH,
+    convert_ncaltech,
     read_atis_bin,
+    representation_from_events,
 )
+
+
+def _encode_atis_event(x: int, y: int, polarity: int, t_us: int) -> bytes:
+    """Encode one event as the 5 ATIS bytes (inverse of ``read_atis_bin``)."""
+    b0 = x & 0xFF
+    b1 = y & 0xFF
+    b2 = ((polarity & 0x1) << 7) | ((t_us >> 16) & 0x7F)
+    b3 = (t_us >> 8) & 0xFF
+    b4 = t_us & 0xFF
+    return bytes([b0, b1, b2, b3, b4])
+
+
+def _write_atis_bin(path, events):
+    """Write a list of ``(x, y, polarity, t_us)`` tuples to an ATIS ``.bin``."""
+    raw = b"".join(_encode_atis_event(*ev) for ev in events)
+    path.write_bytes(raw)
+
+
+def _roundtrip_check():
+    # Encoder must be the exact inverse of the decoder so fixtures are genuine.
+    raw = _encode_atis_event(0x10, 0x20, 1, 0x7FABCD)
+    assert raw == bytes([0x10, 0x20, 0xFF, 0xAB, 0xCD])
 
 
 def test_sensor_constants():
@@ -125,3 +150,135 @@ def test_malformed_length_raises(tmp_path):
 
     with pytest.raises(ValueError, match=str(path)):
         read_atis_bin(path)
+
+
+# --- D2: representation building + N-Caltech tree converter ---
+
+NBINS = 10
+CHANNELS = 2 * NBINS
+
+
+def test_encoder_is_inverse_of_decoder(tmp_path):
+    _roundtrip_check()
+    path = tmp_path / "rt.bin"
+    _write_atis_bin(path, [(5, 6, 1, 4660), (7, 8, 0, 4660)])
+    frame = read_atis_bin(path)
+    assert frame["x"].to_list() == [5, 7]
+    assert frame["y"].to_list() == [6, 8]
+    assert frame["polarity"].to_list() == [1, 0]
+    assert frame["t"].to_list() == [4660, 4660]
+
+
+def test_representation_shape_and_dtype():
+    events = pl.DataFrame(
+        {
+            "x": [10, 11, 12],
+            "y": [20, 21, 22],
+            "t": [100, 200, 300],
+            "polarity": [0, 1, 0],
+        },
+        schema={k: pl.Int64 for k in ("x", "y", "t", "polarity")},
+    )
+    rep = representation_from_events(events, nbins=NBINS)
+    assert rep.shape == (CHANNELS, NCALTECH_HEIGHT, NCALTECH_WIDTH)
+    assert rep.dtype == np.uint8
+
+
+def test_representation_known_event_channel():
+    # Channel formula (read from build_sparse_histogram): polarity-major,
+    #   channel = polarity * nbins + temporal_bin
+    # An event sitting at t == t_min has t_norm == 0 -> temporal_bin 0.
+    # Marker event: polarity 1 at t_min -> channel = 1*nbins + 0 = nbins.
+    # A second (different) event provides the window span so binning is defined.
+    marker_x, marker_y = 30, 40
+    events = pl.DataFrame(
+        {
+            "x": [marker_x, 200],
+            "y": [marker_y, 100],
+            "t": [1000, 9000],
+            "polarity": [1, 0],
+        },
+        schema={k: pl.Int64 for k in ("x", "y", "t", "polarity")},
+    )
+    rep = representation_from_events(events, nbins=NBINS)
+
+    expected_channel = 1 * NBINS + 0
+    assert rep[expected_channel, marker_y, marker_x] == 1
+    # The same pixel must be empty on the polarity-0 half (no leakage).
+    assert rep[0, marker_y, marker_x] == 0
+
+
+def test_representation_degenerate_single_event():
+    events = pl.DataFrame(
+        {"x": [5], "y": [6], "t": [42], "polarity": [1]},
+        schema={k: pl.Int64 for k in ("x", "y", "t", "polarity")},
+    )
+    rep = representation_from_events(events, nbins=NBINS)
+    assert rep.shape == (CHANNELS, NCALTECH_HEIGHT, NCALTECH_WIDTH)
+    assert rep.dtype == np.uint8
+    # The single event must survive (not be divided away or dropped).
+    assert int(rep.sum()) == 1
+    assert rep[NBINS, 6, 5] == 1
+
+
+def _build_two_class_tree(root):
+    # Sorted class order is airplane < camera -> {airplane: 0, camera: 1}.
+    airplane = root / "airplane"
+    camera = root / "camera"
+    airplane.mkdir(parents=True)
+    camera.mkdir(parents=True)
+    _write_atis_bin(
+        airplane / "image_0001.bin",
+        [(10, 20, 1, 1000), (30, 40, 0, 5000)],
+    )
+    _write_atis_bin(
+        airplane / "image_0002.bin",
+        [(11, 21, 0, 2000), (31, 41, 1, 6000)],
+    )
+    _write_atis_bin(
+        camera / "image_0001.bin",
+        [(12, 22, 1, 1500), (32, 42, 0, 5500)],
+    )
+    return ["airplane", "airplane", "camera"]
+
+
+def test_convert_ncaltech_layout_and_labels(tmp_path):
+    root = tmp_path / "ncaltech"
+    expected_class_order = _build_two_class_tree(root)
+    out_dir = tmp_path / "out"
+
+    paths, labels = convert_ncaltech(root, out_dir, nbins=NBINS)
+
+    assert len(paths) == 3
+    assert labels == [0, 0, 1]  # airplane, airplane, camera (sorted classes)
+    assert [p.parent for p in paths] == [out_dir] * 3
+
+    saved_labels = np.load(out_dir / "labels.npy")
+    assert saved_labels.dtype == np.int64
+    assert saved_labels.tolist() == [0, 0, 1]
+
+    for path in paths:
+        assert path.exists()
+        arr = np.load(path)
+        assert arr.shape == (CHANNELS, NCALTECH_HEIGHT, NCALTECH_WIDTH)
+        assert arr.dtype == np.uint8
+        assert int(arr.sum()) > 0
+
+    # The label map follows sorted class-directory names.
+    assert expected_class_order == ["airplane", "airplane", "camera"]
+
+
+def test_convert_ncaltech_empty_root_raises(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(ValueError, match="no class"):
+        convert_ncaltech(empty, tmp_path / "out")
+
+
+def test_convert_ncaltech_class_without_bins_raises(tmp_path):
+    root = tmp_path / "ncaltech"
+    (root / "airplane").mkdir(parents=True)
+    _write_atis_bin(root / "airplane" / "a.bin", [(1, 1, 1, 10)])
+    (root / "camera").mkdir()  # no .bin files
+    with pytest.raises(ValueError, match="camera"):
+        convert_ncaltech(root, tmp_path / "out")

--- a/tests/test_data_ncaltech_e2e.py
+++ b/tests/test_data_ncaltech_e2e.py
@@ -1,0 +1,157 @@
+"""End-to-end test: N-Caltech101 .bin -> convert_ncaltech -> SampleDataset -> DataLoader.
+
+Builds a tiny synthetic 2-class tree of genuine ATIS .bin files, runs them
+through the real converter, and verifies the DataLoader yields the expected
+tensor shapes and labels.  No .npy arrays are fabricated directly.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader  # noqa: E402
+
+from evlib.data import SampleDataset, convert_ncaltech, read_atis_bin  # noqa: E402
+from evlib.data import NCALTECH_HEIGHT, NCALTECH_WIDTH  # noqa: E402
+
+NBINS = 10
+CHANNELS = 2 * NBINS
+
+
+# ---------------------------------------------------------------------------
+# ATIS .bin encoder (same helper as tests/test_data_ncaltech.py)
+# ---------------------------------------------------------------------------
+
+
+def _encode_atis_event(x: int, y: int, polarity: int, t_us: int) -> bytes:
+    """Encode one event as the 5 ATIS bytes (inverse of ``read_atis_bin``)."""
+    b0 = x & 0xFF
+    b1 = y & 0xFF
+    b2 = ((polarity & 0x1) << 7) | ((t_us >> 16) & 0x7F)
+    b3 = (t_us >> 8) & 0xFF
+    b4 = t_us & 0xFF
+    return bytes([b0, b1, b2, b3, b4])
+
+
+def _write_atis_bin(path, events):
+    """Write a list of ``(x, y, polarity, t_us)`` tuples to an ATIS ``.bin``."""
+    raw = b"".join(_encode_atis_event(*ev) for ev in events)
+    path.write_bytes(raw)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_two_class_tree(root):
+    """Create a 2-class tree under *root* with 3 recordings total.
+
+    Sorted class order: airplane (label 0) < camera (label 1).
+    airplane has 2 recordings, camera has 1.
+    """
+    airplane = root / "airplane"
+    camera = root / "camera"
+    airplane.mkdir(parents=True)
+    camera.mkdir(parents=True)
+
+    _write_atis_bin(
+        airplane / "image_0001.bin",
+        [(10, 20, 1, 1000), (30, 40, 0, 5000)],
+    )
+    _write_atis_bin(
+        airplane / "image_0002.bin",
+        [(11, 21, 0, 2000), (31, 41, 1, 6000)],
+    )
+    _write_atis_bin(
+        camera / "image_0001.bin",
+        [(12, 22, 1, 1500), (32, 42, 0, 5500)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_ncaltech_loader_covers_all_samples(tmp_path):
+    """DataLoader iterates over all 3 samples exactly once."""
+    root = tmp_path / "ncaltech_raw"
+    _build_two_class_tree(root)
+    out_dir = tmp_path / "ncaltech_out"
+
+    sample_paths, labels = convert_ncaltech(root, out_dir, nbins=NBINS)
+    assert len(sample_paths) == 3
+    assert labels == [0, 0, 1]
+
+    ds = SampleDataset(sample_paths, labels)
+    dl = DataLoader(ds, batch_size=2, shuffle=True)
+
+    seen = 0
+    for x_batch, y_batch in dl:
+        seen += x_batch.shape[0]
+
+    assert seen == 3
+
+
+def test_ncaltech_loader_batch_tensor_shape(tmp_path):
+    """Each batch tensor has shape [B, 2*nbins, NCALTECH_HEIGHT, NCALTECH_WIDTH]."""
+    root = tmp_path / "ncaltech_raw"
+    _build_two_class_tree(root)
+    out_dir = tmp_path / "ncaltech_out"
+
+    sample_paths, labels = convert_ncaltech(root, out_dir, nbins=NBINS)
+
+    ds = SampleDataset(sample_paths, labels)
+    dl = DataLoader(ds, batch_size=3, shuffle=False)
+
+    batches = list(dl)
+    assert len(batches) == 1
+
+    x_batch, y_batch = batches[0]
+    assert x_batch.shape == (3, CHANNELS, NCALTECH_HEIGHT, NCALTECH_WIDTH)
+
+
+def test_ncaltech_loader_labels_match_converter(tmp_path):
+    """Labels returned by the DataLoader match those from convert_ncaltech."""
+    root = tmp_path / "ncaltech_raw"
+    _build_two_class_tree(root)
+    out_dir = tmp_path / "ncaltech_out"
+
+    sample_paths, labels = convert_ncaltech(root, out_dir, nbins=NBINS)
+
+    ds = SampleDataset(sample_paths, labels)
+    dl = DataLoader(ds, batch_size=3, shuffle=False)
+
+    x_batch, y_batch = next(iter(dl))
+    returned_labels = y_batch.tolist()
+    assert returned_labels == labels
+
+
+def test_ncaltech_sample_nonzero(tmp_path):
+    """Each sample tensor contains at least one non-zero value."""
+    root = tmp_path / "ncaltech_raw"
+    _build_two_class_tree(root)
+    out_dir = tmp_path / "ncaltech_out"
+
+    sample_paths, labels = convert_ncaltech(root, out_dir, nbins=NBINS)
+
+    ds = SampleDataset(sample_paths, labels)
+
+    for i in range(len(ds)):
+        x, y = ds[i]
+        assert x.sum().item() > 0, f"sample {i} is all zeros"
+
+
+def test_ncaltech_public_exports():
+    """The full ncaltech public surface is importable from evlib.data."""
+    from evlib.data import (  # noqa: F401
+        NCALTECH_HEIGHT,
+        NCALTECH_WIDTH,
+        convert_ncaltech,
+        read_atis_bin,
+        representation_from_events,
+    )
+
+    assert NCALTECH_HEIGHT == 180
+    assert NCALTECH_WIDTH == 240

--- a/tests/test_data_package.py
+++ b/tests/test_data_package.py
@@ -6,6 +6,12 @@ def test_evlib_data_imports():
 
 
 def test_legacy_polars_dataset_removed():
-    import evlib.pytorch as p
+    import importlib.util
 
-    assert not hasattr(p, "PolarsDataset"), "legacy PolarsDataset should be retired"
+    assert importlib.util.find_spec("evlib.pytorch") is None, (
+        "legacy evlib.pytorch module should be fully removed"
+    )
+
+    import evlib
+
+    assert not hasattr(evlib, "pytorch"), "evlib should no longer expose pytorch"

--- a/tests/test_data_stream_source_memo.py
+++ b/tests/test_data_stream_source_memo.py
@@ -127,6 +127,31 @@ def test_memoisation_preserves_output(tmp_path):
     assert _windows_equal(second, reference)
 
 
+def test_out_of_bounds_raises_without_building_cache(tmp_path):
+    # An out-of-range read_windows must validate against the cheap grid and
+    # raise BEFORE _ensure_time() does the heavy global-time build, so the
+    # ~2 GB read is never triggered on a misconfigured call. On a fresh source
+    # _t_full stays None after the ValueError.
+    raw_h5 = _make_raw_h5(tmp_path)
+    seq_dir = _make_seq_dir(tmp_path)
+    src = _make_source(raw_h5, seq_dir)
+
+    n_windows = src.window_count()  # 6 for mini_seq
+    assert src._t_full is None
+
+    with pytest.raises(ValueError):
+        src.read_windows(0, n_windows + 1)
+    assert src._t_full is None
+
+    with pytest.raises(ValueError):
+        src.read_windows(-1, 2)
+    assert src._t_full is None
+
+    with pytest.raises(ValueError):
+        src.read_windows(3, 3)
+    assert src._t_full is None
+
+
 def test_pickle_drops_big_array_and_rebuilds(tmp_path):
     raw_h5 = _make_raw_h5(tmp_path)
     seq_dir = _make_seq_dir(tmp_path)

--- a/tests/test_data_stream_source_memo.py
+++ b/tests/test_data_stream_source_memo.py
@@ -1,0 +1,145 @@
+"""Memoisation and pickle-safety tests for EvlibStreamSource global time."""
+
+import pickle
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("h5py")
+pytest.importorskip("hdf5plugin")
+
+import h5py  # noqa: E402
+
+from evlib.data.sources import EvlibStreamSource  # noqa: E402
+
+FIX = Path(__file__).resolve().parent / "data_fixtures" / "mini_seq"
+REPR_NAME = "stacked_histogram_dt50_nbins10"
+
+
+def _make_seq_dir(tmp_path: Path) -> Path:
+    """Copy mini_seq into tmp_path and add the non-ds2 representation h5.
+
+    ``EvlibStreamSource`` is built with ``downsample_by_2=False`` so the dense
+    kernel emits full-resolution ``[20, 8, 12]`` windows; that flag also drives
+    the label source, which reads ``event_representations.h5``. mini_seq ships
+    only the ds2 variant, so we copy the tracked fixture and provide the full-res
+    name as a duplicate (same on-disk array, only used for shape and labels).
+    """
+    seq_dir = tmp_path / "mini_seq"
+    shutil.copytree(FIX, seq_dir)
+    repr_dir = seq_dir / "event_representations_v2" / REPR_NAME
+    shutil.copy(
+        repr_dir / "event_representations_ds2_nearest.h5",
+        repr_dir / "event_representations.h5",
+    )
+    return seq_dir
+
+
+def _make_raw_h5(tmp_path: Path) -> Path:
+    """Write a tiny real raw-events h5 whose times fall inside the grid range.
+
+    The mini_seq grid is ``arange(6) * 50000`` so events span ``[0, 250000]``.
+    Coordinates stay inside the 8x12 sensor used by the fixture.
+    """
+    path = tmp_path / "raw_events.h5"
+    t = np.array(
+        [0, 10_000, 49_000, 60_000, 120_000, 150_000, 199_000, 240_000],
+        dtype=np.uint32,
+    )
+    x = np.array([0, 3, 11, 5, 7, 2, 9, 1], dtype=np.uint16)
+    y = np.array([0, 1, 7, 2, 4, 6, 3, 5], dtype=np.uint16)
+    p = np.array([1, 0, 1, 1, 0, 1, 0, 1], dtype=np.uint8)
+    with h5py.File(str(path), "w") as f:
+        grp = f.create_group("events")
+        grp.create_dataset("t", data=t)
+        grp.create_dataset("x", data=x)
+        grp.create_dataset("y", data=y)
+        grp.create_dataset("p", data=p)
+    return path
+
+
+def _make_source(raw_h5: Path, seq_dir: Path) -> EvlibStreamSource:
+    return EvlibStreamSource(
+        raw_h5=raw_h5,
+        seq_dir=seq_dir,
+        downsample_by_2=False,
+        height=8,
+        width=12,
+        nbins=10,
+        dataset_group="events",
+    )
+
+
+def _windows_equal(a, b) -> bool:
+    ev_a, lab_a = a
+    ev_b, lab_b = b
+    if len(ev_a) != len(ev_b):
+        return False
+    for ta, tb in zip(ev_a, ev_b):
+        if not torch.equal(ta, tb):
+            return False
+    if len(lab_a) != len(lab_b):
+        return False
+    for la, lb in zip(lab_a, lab_b):
+        if la is None or lb is None:
+            if la is not lb:
+                return False
+        elif not torch.equal(la, lb):
+            return False
+    return True
+
+
+def test_global_time_built_once_across_calls(tmp_path, monkeypatch):
+    raw_h5 = _make_raw_h5(tmp_path)
+    seq_dir = _make_seq_dir(tmp_path)
+    src = _make_source(raw_h5, seq_dir)
+
+    calls = {"n": 0}
+    real_accumulate = np.maximum.accumulate
+
+    def counting_accumulate(*args, **kwargs):
+        calls["n"] += 1
+        return real_accumulate(*args, **kwargs)
+
+    monkeypatch.setattr(np.maximum, "accumulate", counting_accumulate)
+
+    src.read_windows(0, 6)
+    src.read_windows(0, 6)
+
+    assert calls["n"] == 1
+
+
+def test_memoisation_preserves_output(tmp_path):
+    raw_h5 = _make_raw_h5(tmp_path)
+    seq_dir = _make_seq_dir(tmp_path)
+
+    fresh = _make_source(raw_h5, seq_dir)
+    reference = fresh.read_windows(0, 6)
+
+    src = _make_source(raw_h5, seq_dir)
+    first = src.read_windows(0, 6)
+    second = src.read_windows(0, 6)
+
+    assert _windows_equal(first, reference)
+    assert _windows_equal(second, reference)
+
+
+def test_pickle_drops_big_array_and_rebuilds(tmp_path):
+    raw_h5 = _make_raw_h5(tmp_path)
+    seq_dir = _make_seq_dir(tmp_path)
+    src = _make_source(raw_h5, seq_dir)
+    reference = src.read_windows(0, 6)
+
+    assert src._t_full is not None
+
+    restored = pickle.loads(pickle.dumps(src))
+    assert restored._t_full is None
+    assert restored._starts is None
+    assert restored._ends is None
+
+    rebuilt = restored.read_windows(0, 6)
+    assert restored._t_full is not None
+    assert _windows_equal(rebuilt, reference)

--- a/tests/test_data_training_smoke.py
+++ b/tests/test_data_training_smoke.py
@@ -1,0 +1,141 @@
+"""Slow end-to-end smoke test for the phase-2 data loader through the backbone.
+
+The phase-1 test (``tests/test_data_rvt_backbone_smoke.py``) already proves the
+plain loader path emits a ``[B, C, H, W]`` (``C == 2*nbins``) per-timestep tensor
+the RVT backbone accepts. This test does NOT duplicate that; it adds the three
+phase-2 integration points that wire the augmentor and the Lightning DataModule
+into the loader path, and that drive the backbone recurrently across timesteps:
+
+1. ``SequenceAugmentor`` composed in the ``SequenceRandomDataset`` path: a
+   post-augmentation collated batch is still rank-4 ``[B, C, H, W]`` with
+   ``C == 2*nbins``, so augmentation preserves the backbone contract.
+2. ``EventDataModule`` wiring: a batch pulled from ``train_dataloader()`` (built
+   with a train-only augmentor) carries the same per-timestep layout, proving the
+   DataModule path composes end to end.
+3. Recurrent LSTM state carried across two timesteps: two correctly-sized real
+   ``[B, 2*nbins, 224, 224]`` tensors are fed through the backbone, threading the
+   first step's per-stage states into the second forward, the genuine recurrent
+   training-step shape.
+
+The tracked fixture ``tests/data_fixtures/mini_seq`` is only 8x12 spatial, which
+the backbone cannot process (total downsample 32, final stage divisible by 7), so
+the augmentor and DataModule run on the tiny fixture while the genuine backbone
+forward uses a correctly-sized real tensor. Real torch tensors throughout, no
+mocks. h5-backed bits are guarded by ``importorskip("h5py")`` and the Lightning
+bit by ``importorskip("pytorch_lightning")`` so CI and Windows skip cleanly.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from evlib.data import (
+    DataKey,
+    PreprocessedH5Source,
+    SequenceAugmentor,
+    SequenceRandomDataset,
+    custom_collate_random,
+)
+
+FIX = Path(__file__).resolve().parent / "data_fixtures" / "mini_seq"
+
+pytestmark = pytest.mark.slow
+
+
+def _assert_per_timestep_layout(batch, expected_channels, sequence_length):
+    """A collated batch carries rank-4 [B, C, H, W] per-timestep tensors."""
+    per_timestep = batch[DataKey.EV_REPR]
+    assert isinstance(per_timestep, list)
+    assert len(per_timestep) == sequence_length
+    first_step = per_timestep[0].float()
+    assert first_step.ndim == 4, "loader must emit a rank-4 per-timestep tensor"
+    assert first_step.shape[1] == expected_channels
+    return first_step
+
+
+def test_augmentor_in_loader_path_preserves_backbone_contract():
+    """SequenceAugmentor composed with collate keeps the [B, C, H, W] contract."""
+    pytest.importorskip("h5py")
+
+    source = PreprocessedH5Source(FIX)
+    expected_channels = 2 * source.nbins
+    assert expected_channels == 20
+
+    # A deterministic, spatial-transform-heavy augmentor; runs fine at 8x12.
+    augmentor = SequenceAugmentor(
+        sampler="random",
+        prob_hflip=1.0,
+        rotate_prob=1.0,
+        zoom_prob=1.0,
+        rng=np.random.default_rng(0),
+    )
+    dataset = SequenceRandomDataset([source], sequence_length=2, augmentor=augmentor)
+    loader = DataLoader(dataset, batch_size=1, collate_fn=custom_collate_random)
+    batch = next(iter(loader))
+
+    _assert_per_timestep_layout(batch, expected_channels, sequence_length=2)
+
+
+def test_event_datamodule_train_dataloader_layout():
+    """EventDataModule.train_dataloader() composes the augmentor end to end."""
+    pytest.importorskip("h5py")
+    pytest.importorskip("pytorch_lightning")
+    from evlib.data import EventDataModule
+
+    source = PreprocessedH5Source(FIX)
+    expected_channels = 2 * source.nbins
+
+    # The random sampler draws fresh params per __getitem__, so a plain random
+    # augmentor is API-correct here (no stream-safety requirement).
+    augmentor = SequenceAugmentor(sampler="random", rng=np.random.default_rng(1))
+    datamodule = EventDataModule(
+        train_sources=[source],
+        val_sources=[source],
+        sequence_length=2,
+        batch_size=1,
+        num_workers=0,
+        sampling="random",
+        augmentor=augmentor,
+    )
+    batch = next(iter(datamodule.train_dataloader()))
+
+    _assert_per_timestep_layout(batch, expected_channels, sequence_length=2)
+
+
+def test_backbone_carries_recurrent_state_across_timesteps():
+    """Two timesteps run recurrently: states0 thread into the second forward."""
+    from evlib.models.rvt_backbone import RVTBackbone, RVTConfig
+
+    config = RVTConfig.tiny()
+    expected_channels = config.input_channels
+    assert expected_channels == 20
+    backbone = RVTBackbone(config).eval()
+
+    # Total downsample is 32 and the final stage must be divisible by 7; 224 -> 7.
+    batch_size = 1
+    height = 224
+    width = 224
+    step_zero = torch.zeros(
+        batch_size, expected_channels, height, width, dtype=torch.float32
+    )
+    step_one = torch.ones(
+        batch_size, expected_channels, height, width, dtype=torch.float32
+    )
+
+    with torch.no_grad():
+        out0, states0 = backbone(step_zero, previous_states=None)
+        out1, states1 = backbone(step_one, previous_states=states0)
+
+    for stage_outputs in (out0, out1):
+        assert set(stage_outputs.keys()) == {1, 2, 3, 4}
+        for feature in stage_outputs.values():
+            assert feature.ndim == 4
+            assert feature.shape[0] == batch_size
+
+    for new_states in (states0, states1):
+        assert len(new_states) == config.num_stages
+        for hidden, cell in new_states:
+            assert hidden.ndim == 4 and cell.ndim == 4


### PR DESCRIPTION
# feat(data): evlib.data training-readiness (phase 2) - augmentation, label preprocessing, N-Caltech101

Takes the `evlib.data` PyTorch loader from "eval/inference-correct, reads a preprocessed directory" to "training-ready, builds from raw". It builds directly on phase 1 (PR #52: sources, datasets, collate, optional Lightning DataModule) and adds four workstreams plus an end-to-end smoke test. Scope is the detection sequence path (RVT/SSM) and the sample-level classification path (N-Caltech101). The Polars / LazyFrame / `evlib.rvt` machinery is untouched.

This is the foundation the next phase (running real N-Caltech101 classification and reproducing RVT/SSM training numbers) sits on.

## What is new

- Stream memoisation (`sources.py`): `EvlibStreamSource` now builds the corrected global event-time array and the window start/end indices once per worker instead of re-reading and re-correcting the full time column (about 2 GB on a real gen4 sequence) on every `read_windows` call. The large array is excluded from pickle via `__getstate__`/`__setstate__`, so each DataLoader worker rebuilds its own lazily and the source stays fork/spawn safe. Valid-call output is unchanged.
- Bbox-aware augmentation (`augment.py`): a new `SequenceAugmentor` applies RVT-matched horizontal-flip, rotation, and zoom-in/zoom-out to both the `[C,H,W]` representation tensors and their yolox boxes together. Parameters are drawn once per sequence; padded windows are left untouched. It is wired as an optional `augmentor=` seam into `SequenceRandomDataset` (fresh draw per item), `SequenceStreamDataset` (one frozen draw per source, via `for_source()`, with an eager `stream_safe()` check at construction), and `EventDataModule` (train split only). A slow gate forces identical parameters into both evlib's augmentor and the vendored RVT `RandomSpatialAugmentorGenX` and asserts byte-identical tensors plus matching boxes for each transform.
- RVT label preprocessing (`label_preprocess.py`): reproduces RVT's offline label pipeline from a raw Prophesee `*_bbox.npy`: the exact bbox filter chain (gen4 class keep, crop-to-FOV, conservative size filter, train-only faulty-huge removal), object-frame selection (base cadence, alignment, jitter tolerance), the event-representation window-end grid, `objframe_idx_2_repr_idx`, and the `labels.npz` / `timestamps_us.npy` / index writers. The `track_id` field is carried through. A slow gate proves the output is byte-identical (values and dtype) to real RVT-produced artifacts on a staged gen4 sequence.
- N-Caltech101 classification path (`ncaltech.py`): an ATIS 5-byte `.bin` reader (`read_atis_bin`, sensor 240x180), a per-recording stacked-histogram builder reusing `evlib.rvt`'s `build_sparse_histogram` + `scatter_window_dense` (one `[2*nbins,180,240]` window per recording), and `convert_ncaltech`, which walks a class tree, builds the sorted class-to-int label map, and writes the per-recording `.npy` plus a `labels.npy` that `SampleDataset` consumes. An end-to-end test runs real ATIS bytes through the converter into `SampleDataset` and a `DataLoader`.
- Training smoke test (`test_data_training_smoke.py`, slow): wires `EventDataModule` -> dataset -> `PreprocessedH5Source` -> `SequenceAugmentor` -> collate -> RVT backbone, and drives the backbone recurrently across two timesteps (threading LSTM state forward), proving the whole phase-2 stack composes.

## Repr directory naming

Real RVT/eTram data and B's byte-identity gate use the upstream on-disk directory name `stacked_histogram_dt=50_nbins=10` (exposed as `RVT_REPR_DIR_NAME`). evlib's own pipeline (`evlib.rvt`) and the phase-1 source defaults use the evlib-native form `stacked_histogram_dt50_nbins10`. To keep evlib-native components pairing by default, `preprocess_sequence` defaults to the evlib-native name (`EVLIB_REPR_DIR_NAME`); callers reproducing the upstream layout pass `repr_dir_name=RVT_REPR_DIR_NAME` explicitly (the byte-identity gate does). A full unification of the two conventions across `evlib.rvt`, the source defaults, and the fixtures is a tracked follow-up, not in this PR.

## Testing

- Full data suite green: 103 passed, 10 skipped (slow and local-only-data gates) on a default `pytest`.
- Local-only slow gates (run with `--run-slow`, skip cleanly on CI / without the data): the RVT augmentation bit-equivalence gate, the gen4 label-preprocessing byte-identity gate (passed on the real staged moorea sequence), and the RVT-backbone training smoke test.

## Notes for review

- D (N-Caltech101) is code-complete and fixture-tested, but the real N-Caltech101 dataset is not bundled. Running `convert_ncaltech` over the real dataset and reproducing classification numbers is the immediate follow-up.
- B's byte-identity gate uses a gen4 `val` sequence staged locally under the gitignored `data/gen4_label_preprocess/` (a roughly 1 MB raw `_bbox.npy` plus the processed ground truth); the train-only faulty-huge-bbox filter is exercised by unit tests rather than the real-data gate.
- Deferred (tracked) follow-ups: the repr-naming unification; strengthening the smoke test to assert augmentation/recurrence numerically change the output; two cosmetic D1 test items.
- The old `evlib.pytorch` module is removed in this PR. Phase 1 (PR #52) had already retired its `PolarsDataset` (a generic flat-event-batch iterator with no sequence, recurrent-state, or label concept, so unusable for RVT/SSM-style training) along with its `create_dataloader` / `load_rvt_data` / transform helpers, leaving `pytorch.py` an empty stub. This PR deletes that stub and its `evlib.__init__` wiring entirely; the retirement test now asserts the whole `evlib.pytorch` module is gone rather than just lacking the class. All PyTorch data loading lives in `evlib.data`. Anyone still importing `evlib.pytorch` (which already exported nothing) should import from `evlib.data` instead.
