### PR TITLE
fix(test): skip weight-load checks when the gitignored rvt-t.ckpt is absent

### DIFF
--- a/tests/test_rvt_weight_load.py
+++ b/tests/test_rvt_weight_load.py
@@ -32,6 +32,14 @@ CHECKPOINT_PATH = (
     / "rvt-t.ckpt"
 )
 
+# rvt-t.ckpt (71 MB) is intentionally gitignored, so it is present locally but
+# absent on CI runners. Skip the whole module when it is missing, matching how
+# the repo gates its other local-only-data suites, rather than erroring.
+pytestmark = pytest.mark.skipif(
+    not CHECKPOINT_PATH.exists(),
+    reason="rvt-t.ckpt is gitignored (local-only); skipping weight-load checks",
+)
+
 # Keys in the raw Lightning checkpoint that are intentionally not model
 # parameters (optimiser state, training bookkeeping, etc.). The loader returns
 # ``None`` for these via ``_convert_checkpoint_key``. Enumerated explicitly so a


### PR DESCRIPTION
rvt-t.ckpt (71 MB) is intentionally gitignored, so it is present locally but absent on CI. tests/test_rvt_weight_load.py asserted the checkpoint exists (6 setup ERRORs) and built RVT(pretrained=True) which now raises when the file is absent (2 FAILs), breaking ubuntu and macOS after PR #54. This gates the module with a module-level skipif on the checkpoint's presence, matching the repo's other local-only-data gates: it runs locally where the weights exist and skips on CI. Windows still carries the separate, pre-existing torchvision/pycocotools install issue (deferred).